### PR TITLE
Fix #18: route all registry calls through the OS-trust-store TLS context

### DIFF
--- a/cg/infra_urllib_client_python/.validation_stamp.json
+++ b/cg/infra_urllib_client_python/.validation_stamp.json
@@ -1,1 +1,1 @@
-{"fingerprint": "a4899bea86a3889fd48e3ac574210ca59d03ae59c7932eff58163e2045848a26", "stamped_at": "2026-06-13T17:34:55.805733+00:00", "language": "python", "engine_version": 1, "runtime": "python 3.14.5", "test_results": {}, "validated_at": "2026-06-13T17:34:55.805379+00:00"}
+{"fingerprint": "c1a0b360a6ba3fa64ea8d05fd281e58c7e74721d6f1915436bb0b6d46b549737", "stamped_at": "2026-06-14T04:49:40.735677+00:00", "language": "python", "engine_version": 1, "runtime": "python 3.14.5", "test_results": {}, "validated_at": "2026-06-14T04:49:40.735313+00:00"}

--- a/cg/infra_urllib_client_python/src/urllib_client.py
+++ b/cg/infra_urllib_client_python/src/urllib_client.py
@@ -180,21 +180,58 @@ class HTTPClient:
                     return json.loads(raw)
                 except ValueError:
                     return {"error": "Non-JSON response body", "status_code": resp.status}
-        except urllib.error.HTTPError as e:
+        except Exception as e:
+            return self._error_dict(e)
+
+    @staticmethod
+    def _error_dict(e: Exception) -> dict:
+        """Map a request exception to the shared {error, status_code} shape."""
+        if isinstance(e, urllib.error.HTTPError):
             err_body = {}
             try:
                 err_body = json.loads(e.read())
             except Exception:
                 pass
-            # Prefer the server-provided detail, fall back to the generic HTTP error.
-            return {
-                "error": err_body.get("detail", str(e)),
-                "status_code": e.code,
-            }
-        except urllib.error.URLError as e:
+            detail = err_body.get("detail", str(e)) if isinstance(err_body, dict) else str(e)
+            return {"error": detail, "status_code": e.code}
+        if isinstance(e, urllib.error.URLError):
             return {"error": f"Network error: {e.reason}", "status_code": None}
+        return {"error": str(e), "status_code": None}
+
+    def request_raw(
+        self,
+        method: str,
+        path: str,
+        data: bytes | None = None,
+        base_url: str | None = None,
+        headers: dict | None = None,
+        timeout: float | None = None,
+        content_type: str | None = None,
+    ) -> dict:
+        """Make a request and return the unparsed response.
+
+        Returns {"status": int, "headers": dict, "body": bytes} on success,
+        or the same {"error", "status_code"} shape as the JSON methods on
+        failure. Use this for binary payloads (zip/tar downloads), endpoints
+        whose metadata rides in response headers, or health checks where only
+        the status code matters. The TLS context and auth headers are applied
+        exactly as for the JSON methods, so callers never touch raw urllib.
+        """
+        resolved_base = self._resolve_base(base_url)
+        url = resolved_base + path
+        request_headers = self._build_headers(resolved_base, headers, content_type)
+        req = urllib.request.Request(url, data=data, headers=request_headers, method=method)
+        context = self._get_ssl_context() if url.lower().startswith("https") else None
+        try:
+            with urllib.request.urlopen(req, timeout=timeout or self.default_timeout,
+                                        context=context) as resp:
+                return {
+                    "status": resp.status,
+                    "headers": dict(resp.headers.items()),
+                    "body": resp.read(),
+                }
         except Exception as e:
-            return {"error": str(e), "status_code": None}
+            return self._error_dict(e)
 
     def get(self, path: str, base_url: str | None = None,
             headers: dict | None = None, timeout: float | None = None) -> dict:

--- a/cg/infra_urllib_client_python/tests/test_urllib_client.py
+++ b/cg/infra_urllib_client_python/tests/test_urllib_client.py
@@ -232,6 +232,46 @@ def test_empty_body_returns_empty_dict(server):
     assert r == {}
 
 
+# ---- request_raw ---------------------------------------------------------
+
+def test_request_raw_returns_status_headers_body(server):
+    _, base, H = server
+    H.responses[("GET", "/v1/raw")] = (200, b"plain text not json")
+    c = HTTPClient(base_url=base)
+    r = c.request_raw("GET", "/v1/raw")
+    assert r["status"] == 200
+    assert r["body"] == b"plain text not json"
+    # headers come back as a plain dict, never JSON-parsed
+    assert r["headers"]["Content-Type"] == "application/json"
+
+
+def test_request_raw_binary_body_unparsed(server):
+    _, base, H = server
+    blob = bytes(range(256))
+    H.responses[("GET", "/v1/zip")] = (200, blob)
+    c = HTTPClient(base_url=base)
+    r = c.request_raw("GET", "/v1/zip")
+    assert r["body"] == blob  # raw bytes, no decode/parse
+
+
+def test_request_raw_http_error_returns_error_dict(server):
+    _, base, H = server
+    H.responses[("GET", "/v1/missing")] = (404, {"detail": "nope"})
+    c = HTTPClient(base_url=base)
+    r = c.request_raw("GET", "/v1/missing")
+    assert r["error"] == "nope"
+    assert r["status_code"] == 404
+    assert "body" not in r
+
+
+def test_request_raw_applies_auth_headers(server):
+    _, base, H = server
+    H.responses[("GET", "/v1/raw")] = (200, b"ok")
+    c = HTTPClient(base_url=base, auth_headers=lambda url: {"Authorization": "Bearer t"})
+    c.request_raw("GET", "/v1/raw")
+    assert H.received[-1]["headers"]["authorization"] == "Bearer t"
+
+
 # ---- Multipart -----------------------------------------------------------
 
 def test_multipart_fields_only(server):

--- a/cg/infra_urllib_client_python/widget.json
+++ b/cg/infra_urllib_client_python/widget.json
@@ -2,7 +2,7 @@
   "meta": {
     "id": "infra-urllib-client-python",
     "name": "Urllib Client",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "domain": "infra",
     "tags": [
       "http",
@@ -25,7 +25,7 @@
   },
   "validation": {
     "engine_version": 1,
-    "validated_at": "2026-06-13T17:34:35.184069+00:00",
+    "validated_at": "2026-06-14T05:28:55.615700+00:00",
     "runtime": "python 3.14.5"
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cartograph-cli"
-version = "0.7.8"
+version = "0.7.9"
 description = "Widget library manager for AI agents — CLI"
 readme = "README.md"
 license = "MIT"

--- a/src/cartograph/auth.py
+++ b/src/cartograph/auth.py
@@ -160,7 +160,8 @@ def _refresh_id_token(refresh_token: str) -> str | None:
 
     req = urllib.request.Request(token_url, data=data, method="POST")
     try:
-        with urllib.request.urlopen(req, timeout=10) as resp:
+        from .net_tls import registry_ssl_context
+        with urllib.request.urlopen(req, timeout=10, context=registry_ssl_context()) as resp:
             result = json.loads(resp.read())
         new_id_token = result.get("id_token")
         if new_id_token:

--- a/src/cartograph/cloud.py
+++ b/src/cartograph/cloud.py
@@ -1,8 +1,10 @@
 """
 Cartograph cloud registry client.
 
-All network activity is in this module.  Everything uses urllib.request so
-there are no extra dependencies.  If the user is not authenticated or the
+All network activity is in this module. Every request is routed through the
+dogfooded `infra-urllib-client-python` widget (stdlib-only, so no extra
+dependencies), which applies the OS-trust-store TLS context uniformly - there
+is no raw urllib here to bypass it. If the user is not authenticated or the
 registry is unreachable, functions degrade gracefully and return structured
 error dicts rather than raising.
 
@@ -18,9 +20,7 @@ Install paths remain cg/<widget-id>/ regardless of source.
 import json
 import logging
 import os
-import urllib.error
 import urllib.parse
-import urllib.request
 import zipfile
 from io import BytesIO
 
@@ -59,26 +59,12 @@ endpoint, get_endpoints = _load_endpoint_decorator()
 # Low-level helpers
 # ---------------------------------------------------------------------------
 # HTTP plumbing is delegated to the dogfooded `infra-urllib-client-python`
-# widget. The five module-level helpers below (_get/_post/_patch/_delete/
-# _post_multipart) keep their names and signatures so every existing caller
-# works unchanged, but their bodies are thin wrappers around a shared
-# HTTPClient instance. Two functions stay on raw urllib and are
-# intentionally not routed through the client:
-#   * download_widget() — needs response-header access (X-Widget-Version,
-#     X-Widget-Governance) which the widget's client doesn't expose.
-#   * login_with_credentials() — distinct auth path, different endpoint
-#     surface, not worth routing through the shared client.
-# is_available() also uses raw urllib so it can skip auth entirely.
-
-def _headers(registry_url: str | None = None) -> dict:
-    """Header dict including auth, used by the raw-urllib paths above."""
-    from .auth import get_token
-    token = get_token(registry_url)
-    h = {"Content-Type": "application/json", "Accept": "application/json"}
-    if token:
-        h["Authorization"] = f"Bearer {token}"
-    return h
-
+# widget. The module-level helpers below (_get/_post/_patch/_delete/
+# _post_multipart for JSON, request_raw via _http_client() for binary and
+# header-bearing responses) keep their names and signatures so every existing
+# caller works unchanged, but their bodies are thin wrappers around a shared
+# HTTPClient instance. Nothing here uses raw urllib, so the widget's
+# OS-trust-store TLS context applies to every call uniformly.
 
 def _registry_url() -> str:
     from .auth import get_registry_url
@@ -164,10 +150,8 @@ def _post_multipart(path: str, fields: dict, file_data: bytes, filename: str,
 def is_available() -> bool:
     """Return True if the registry responds to a health check."""
     try:
-        url = _registry_url() + "/health"
-        req = urllib.request.Request(url, headers={"Accept": "application/json"})
-        with urllib.request.urlopen(req, timeout=5) as resp:
-            return resp.status == 200
+        r = _http_client().request_raw("GET", "/health", base_url=_registry_url(), timeout=5)
+        return r.get("status") == 200
     except Exception:
         return False
 
@@ -408,29 +392,24 @@ def download_widget(owner_handle: str, widget_id: str,
     Returns {"zip_bytes": bytes, "version": str} on success,
     or {"error": ...} on failure.
     """
-    base = registry_url.rstrip("/") if registry_url else _registry_url()
-    url = (
-        base
-        + f"/v1/widgets/{urllib.parse.quote(owner_handle)}"
+    path = (
+        f"/v1/widgets/{urllib.parse.quote(owner_handle)}"
         f"/{urllib.parse.quote(widget_id)}/download"
     )
-    headers = _headers(registry_url)
-    headers["Accept"] = "application/zip"
-    req = urllib.request.Request(url, headers=headers)
-    try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            version = resp.headers.get("X-Widget-Version", "0.0.0")
-            governance = resp.headers.get("X-Widget-Governance")
-            return {"zip_bytes": resp.read(), "version": version, "governance": governance}
-    except urllib.error.HTTPError as e:
-        body = {}
-        try:
-            body = json.loads(e.read())
-        except Exception:
-            pass
-        return {"error": body.get("detail", str(e)), "status_code": e.code}
-    except Exception as e:
-        return {"error": f"Download failed: {e}"}
+    r = _http_client().request_raw(
+        "GET", path,
+        base_url=_resolve_base(registry_url),
+        headers={"Accept": "application/zip"},
+        timeout=30,
+    )
+    if "error" in r:
+        return r
+    headers = r["headers"]
+    return {
+        "zip_bytes": r["body"],
+        "version": headers.get("X-Widget-Version", "0.0.0"),
+        "governance": headers.get("X-Widget-Governance"),
+    }
 
 
 @endpoint("GET", "/v1/registry/info",
@@ -592,22 +571,22 @@ def login_with_credentials(id_token: str, refresh_token: str,
 
     Returns {"status": "success", "owner": ...} or {"error": ...}.
     """
-    from .auth import save_credentials, get_registry_url
+    from .auth import save_credentials
 
-    url = get_registry_url().rstrip("/") + "/v1/auth/me"
-    req = urllib.request.Request(
-        url,
-        headers={"Authorization": f"Bearer {id_token}", "Accept": "application/json"},
+    # Validate the *candidate* id_token (not the stored one), so override the
+    # Authorization header the client's auth callback would otherwise inject.
+    data = _http_client().get(
+        "/v1/auth/me",
+        base_url=_registry_url(),
+        headers={"Authorization": f"Bearer {id_token}"},
     )
-    try:
-        with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
-            data = json.loads(resp.read())
-    except urllib.error.HTTPError as e:
-        if e.code == 401:
+    if "error" in data:
+        code = data.get("status_code")
+        if code == 401:
             return {"error": "Invalid token."}
-        return {"error": f"Registry error: {e.code}"}
-    except Exception as e:
-        return {"error": str(e)}
+        if code is not None:
+            return {"error": f"Registry error: {code}"}
+        return {"error": data["error"]}
 
     save_credentials(id_token, refresh_token, signing_key)
     return {"status": "success", "owner": data.get("owner") or data.get("username", "unknown")}
@@ -862,28 +841,20 @@ def proposal_diff(owner_handle: str, widget_id: str,
 
     Returns {"diff": str} on success, or {"error": ...} on failure.
     """
-    base = registry_url.rstrip("/") if registry_url else _registry_url()
-    url = (
-        base
-        + f"/v1/widgets/{urllib.parse.quote(owner_handle)}"
+    path = (
+        f"/v1/widgets/{urllib.parse.quote(owner_handle)}"
         f"/{urllib.parse.quote(widget_id)}"
         f"/proposals/{urllib.parse.quote(proposal_id)}/diff"
     )
-    headers = _headers(registry_url)
-    headers["Accept"] = "text/plain"
-    req = urllib.request.Request(url, headers=headers)
-    try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            return {"diff": resp.read().decode("utf-8", errors="replace")}
-    except urllib.error.HTTPError as e:
-        body = {}
-        try:
-            body = json.loads(e.read())
-        except Exception:
-            pass
-        return {"error": body.get("detail", str(e)), "status_code": e.code}
-    except Exception as e:
-        return {"error": f"Diff fetch failed: {e}"}
+    r = _http_client().request_raw(
+        "GET", path,
+        base_url=_resolve_base(registry_url),
+        headers={"Accept": "text/plain"},
+        timeout=30,
+    )
+    if "error" in r:
+        return r
+    return {"diff": r["body"].decode("utf-8", errors="replace")}
 
 
 @endpoint("POST", "/v1/widgets/{owner_handle}/{widget_id}/proposals/{proposal_id}/accept",
@@ -970,27 +941,21 @@ def download_blueprint(owner_handle: str, blueprint_id: str,
     Returns {"tar_bytes": bytes, "version": str} on success,
     or {"error": ...} on failure.
     """
-    base = registry_url.rstrip("/") if registry_url else _registry_url()
     path = (
         f"/v1/blueprints/{urllib.parse.quote(owner_handle)}"
         f"/{urllib.parse.quote(blueprint_id)}/download"
     )
     if version:
         path += f"?version={urllib.parse.quote(version)}"
-    url = base + path
-    headers = _headers(registry_url)
-    headers["Accept"] = "application/gzip"
-    req = urllib.request.Request(url, headers=headers)
-    try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            ver = resp.headers.get("X-Blueprint-Version", version or "0.0.0")
-            return {"tar_bytes": resp.read(), "version": ver}
-    except urllib.error.HTTPError as e:
-        body = {}
-        try:
-            body = json.loads(e.read())
-        except Exception:
-            pass
-        return {"error": body.get("detail", f"HTTP {e.code}")}
-    except urllib.error.URLError as e:
-        return {"error": f"Network error: {e.reason}"}
+    r = _http_client().request_raw(
+        "GET", path,
+        base_url=_resolve_base(registry_url),
+        headers={"Accept": "application/gzip"},
+        timeout=30,
+    )
+    if "error" in r:
+        return r
+    return {
+        "tar_bytes": r["body"],
+        "version": r["headers"].get("X-Blueprint-Version", version or "0.0.0"),
+    }

--- a/src/cartograph/config.py
+++ b/src/cartograph/config.py
@@ -17,6 +17,8 @@ import os
 import urllib.error
 import urllib.request
 
+from .net_tls import registry_ssl_context
+
 try:
     import tomllib
 except ModuleNotFoundError:
@@ -345,7 +347,7 @@ def _fetch_registry_info(url: str) -> dict:
             url.rstrip("/") + "/info",
             headers={"Accept": "application/json"},
         )
-        with urllib.request.urlopen(req, timeout=5) as resp:
+        with urllib.request.urlopen(req, timeout=5, context=registry_ssl_context()) as resp:
             return json.loads(resp.read())
     except urllib.error.HTTPError as e:
         return {"error": f"Registry /info returned HTTP {e.code}"}

--- a/src/cartograph/engine.py
+++ b/src/cartograph/engine.py
@@ -121,16 +121,22 @@ def _ensure_global_rules() -> None:
 
 
 def _resolve_library_path() -> str:
-    """Resolve widget library path: env var > user data dir > dev repo sibling."""
+    """Resolve the widget library path.
+
+    Precedence: WIDGET_LIBRARY_PATH env override > platform user data dir.
+
+    The platform user data dir is the single canonical library. A repo-local
+    `Widget_Library/` sibling used to auto-shadow this whenever it merely
+    existed and cartograph ran from a source checkout, which silently split the
+    library in two (source commands hit the repo dir, installed commands +
+    `cloud sync` hit the platform dir, and they diverged). That existence-based
+    override is removed: to point a dev checkout at a custom library, set
+    WIDGET_LIBRARY_PATH explicitly so the choice is visible (and `doctor`
+    prints the resolved path).
+    """
     if "WIDGET_LIBRARY_PATH" in os.environ:
         _ensure_global_rules()
         return os.environ["WIDGET_LIBRARY_PATH"]
-    # Dev: repo sibling takes priority over user data dir so local edits work
-    _repo_lib = os.path.join(REPO_DIR, "Widget_Library")
-    if os.path.exists(_repo_lib):
-        _ensure_global_rules()
-        return _repo_lib
-    # Normal install: use platform user data dir, seeding if needed
     user_lib = os.path.join(_user_data_dir(), "Widget_Library")
     _ensure_library(user_lib)  # _ensure_library calls _ensure_global_rules internally
     return user_lib

--- a/src/cartograph/net_tls.py
+++ b/src/cartograph/net_tls.py
@@ -1,0 +1,23 @@
+"""Shared TLS context for every outbound HTTPS call the CLI makes.
+
+stdlib `ssl` verifies against OpenSSL's default cert path. On the python.org
+macOS build that path is empty (`ssl.get_default_verify_paths().cafile is None`),
+so every registry call fails with CERTIFICATE_VERIFY_FAILED until the user runs
+`Install Certificates.command` by hand. The fix already lives in the
+`infra-urllib-client-python` widget, which builds a verifying context from the
+OS trust store (the macOS keychains, read via the built-in `security` tool).
+
+This module is the single seam that wires that widget into the CLI's own
+`urllib.request.urlopen` call sites. Pass `context=registry_ssl_context()` to
+every HTTPS request; urlopen ignores the context for plain-http targets.
+"""
+
+from cg.infra_urllib_client_python.src.urllib_client import default_ssl_context
+
+
+def registry_ssl_context():
+    """Process-wide verifying SSL context backed by the OS trust store.
+
+    Cached inside the widget, so repeated calls never re-export the keychain.
+    """
+    return default_ssl_context()

--- a/src/cartograph/update_check.py
+++ b/src/cartograph/update_check.py
@@ -77,7 +77,8 @@ def _fetch_latest_version() -> str | None:
         _PYPI_URL,
         headers={"Accept": "application/json", "User-Agent": f"cartograph/{_current_version()}"},
     )
-    with urllib.request.urlopen(req, timeout=_REQUEST_TIMEOUT) as resp:
+    from .net_tls import registry_ssl_context
+    with urllib.request.urlopen(req, timeout=_REQUEST_TIMEOUT, context=registry_ssl_context()) as resp:
         data = json.loads(resp.read())
     latest = data.get("info", {}).get("version")
     return latest if isinstance(latest, str) and latest else None

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -38,9 +38,14 @@ def cli_env(tmp_library, tmp_path):
     # would break site-packages resolution when cartograph is --user-installed).
     env["XDG_DATA_HOME"] = str(tmp_path / "xdg-data")
     env["XDG_CONFIG_HOME"] = str(tmp_path / "xdg-config")
-    # Ensure src/ is importable regardless of how cartograph was installed
-    repo_src = os.path.join(os.path.dirname(os.path.dirname(__file__)), "src")
-    env["PYTHONPATH"] = repo_src + os.pathsep + env.get("PYTHONPATH", "")
+    # Ensure src/ (cartograph) and the repo root (the cg/ widget tree) are
+    # importable regardless of how cartograph was installed. Without the repo
+    # root, `import cg` falls through to any stale --user-installed copy.
+    repo_root = os.path.dirname(os.path.dirname(__file__))
+    repo_src = os.path.join(repo_root, "src")
+    env["PYTHONPATH"] = os.pathsep.join(
+        [repo_src, repo_root, env.get("PYTHONPATH", "")]
+    )
     return env
 
 

--- a/tests/test_tls_context_guard.py
+++ b/tests/test_tls_context_guard.py
@@ -29,7 +29,7 @@ def _is_urlopen(call: ast.Call) -> bool:
 def test_every_urlopen_passes_a_tls_context():
     offenders = []
     for path in SRC.rglob("*.py"):
-        tree = ast.parse(path.read_text(), filename=str(path))
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
         for node in ast.walk(tree):
             if isinstance(node, ast.Call) and _is_urlopen(node):
                 if "context" not in {kw.arg for kw in node.keywords}:

--- a/tests/test_tls_context_guard.py
+++ b/tests/test_tls_context_guard.py
@@ -1,0 +1,42 @@
+"""Guard against the issue #18 macOS regression.
+
+On the python.org macOS build, OpenSSL's default cert store is empty, so any
+`urllib.request.urlopen(...)` without an OS-trust-store SSL context fails with
+CERTIFICATE_VERIFY_FAILED ("Public Registry Can't Be Reached"). Most network
+calls route through the `infra-urllib-client-python` widget, which applies the
+context for us; the few that stay on raw urllib must pass
+`context=registry_ssl_context()` explicitly.
+
+This test parses the CLI source and fails if any raw `urlopen` call omits a
+`context=` keyword. A new bare urlopen is a red build, not a shipped Mac bug.
+"""
+
+import ast
+import pathlib
+
+SRC = pathlib.Path(__file__).resolve().parent.parent / "src" / "cartograph"
+
+
+def _is_urlopen(call: ast.Call) -> bool:
+    f = call.func
+    if isinstance(f, ast.Attribute):
+        return f.attr == "urlopen"
+    if isinstance(f, ast.Name):
+        return f.id == "urlopen"
+    return False
+
+
+def test_every_urlopen_passes_a_tls_context():
+    offenders = []
+    for path in SRC.rglob("*.py"):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and _is_urlopen(node):
+                if "context" not in {kw.arg for kw in node.keywords}:
+                    offenders.append(f"{path.relative_to(SRC)}:{node.lineno}")
+    assert not offenders, (
+        "Bare urlopen without context= reintroduces the macOS "
+        "CERTIFICATE_VERIFY_FAILED bug (issue #18). Pass "
+        "context=registry_ssl_context() or route the call through the "
+        "infra-urllib-client-python widget. Offenders: " + ", ".join(offenders)
+    )


### PR DESCRIPTION
## Problem

Issue #18 — on the python.org macOS build the public registry is unreachable. The v0.7.8 trust-store fix shipped in `infra-urllib-client-python` but the CLI's own `urllib.request.urlopen` call sites never used it, so on an empty OpenSSL cert store every bare-urlopen registry call fails with `CERTIFICATE_VERIFY_FAILED`. `search` worked (routes through the widget's `HTTPClient`); `doctor`'s `is_available()`, download, diff, login, blueprint download, token refresh, and the update check did not.

Root-caused by reproducing on a real macOS 26 / Python 3.14 box: bare default context → `CERTIFICATE_VERIFY_FAILED`; OS-keychain context → HTTP 200.

## Fix (structural, not per-call patches)

- **Widget:** `infra-urllib-client-python` gains `request_raw()` → `{status, headers, body-bytes}` (or the shared error dict), with the trust-store context + auth applied like every other method. This is the capability the raw paths bypassed the widget for (binary downloads, header metadata, health checks).
- **cloud.py now has zero raw urllib:** `is_available`, `download_widget`, `proposal_diff`, `download_blueprint`, `login_with_credentials` all route through the widget. Dead `_headers` helper and stale comments removed.
- **net_tls.registry_ssl_context()** is the single seam for the two calls that legitimately stay raw (auth.py token refresh, update_check → PyPI).
- **Guard test** (`test_tls_context_guard.py`) AST-fails the build if any `urlopen` in `src/cartograph` omits `context=` — a future bare urlopen is a red build, not a shipped Mac regression.
- **Contract-test harness** puts the repo root on `PYTHONPATH` so the subprocess imports the repo's `cg/` widgets, not a stale `--user`-installed copy.

## Verification

- Reproduced the failure and confirmed the fix against the live endpoint on the affected Mac.
- Full suite: 783 passed. Widget: 36 passed + `cartograph validate` clean.

Closes #18