### PR TITLE
0.7.10: show-unavailable cloud scoping + Windows encoding sweep + SPICE echo

### DIFF
--- a/REGISTRY.md
+++ b/REGISTRY.md
@@ -72,11 +72,17 @@ A read-only registry needs four endpoints:
 
 ### Search
 
-`GET /v1/widgets/search?q=<query>&top_k=<n>[&domain=<d>][&language=<l>]`
+`GET /v1/widgets/search?q=<query>&top_k=<n>[&domain=<d>][&language=<l>][&languages=<l1,l2,...>]`
 
 - Return at most `top_k` results as `{"widgets": [<row>, ...]}` in ranked
   order (rule 1 above).
 - `domain` and `language` are hard filters when present.
+- `languages` (comma-separated) is a hard filter to the set of languages
+  the client can use locally (`show-unavailable false`). Apply it BEFORE
+  ranking and truncating to `top_k` so the page fills with installable
+  widgets. A registry that ignores it stays correct: the client re-filters
+  client-side as a backstop, it just wastes payload. `language` (singular,
+  the user's `--language`) and `languages` may both be present; honor both.
 - How you rank is entirely yours: lexical, embeddings, popularity-weighted,
   hand-curated. The client-side budget decides how many of your rows are
   shown next to local and other-registry results, but never their order.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cartograph-cli"
-version = "0.7.9"
+version = "0.7.10"
 description = "Widget library manager for AI agents — CLI"
 readme = "README.md"
 license = "MIT"

--- a/src/cartograph/architect/scaffold.py
+++ b/src/cartograph/architect/scaffold.py
@@ -136,5 +136,5 @@ def write_architect_template(path: str, *, overwrite: bool = False) -> None:
     parent = os.path.dirname(path)
     if parent:
         os.makedirs(parent, exist_ok=True)
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         f.write(_TEMPLATE)

--- a/src/cartograph/architect/validator.py
+++ b/src/cartograph/architect/validator.py
@@ -44,7 +44,7 @@ def _load_valid_domains() -> frozenset:
         os.path.dirname(__file__), os.pardir, "library_config.json"
     )
     try:
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             return frozenset(json.load(f)["domains"].keys())
     except Exception:
         return frozenset()

--- a/src/cartograph/auth.py
+++ b/src/cartograph/auth.py
@@ -60,7 +60,7 @@ def _registry_tokens_path() -> str:
 
 def _read_registry_tokens() -> dict:
     try:
-        with open(_registry_tokens_path()) as f:
+        with open(_registry_tokens_path(), encoding="utf-8") as f:
             return json.load(f)
     except Exception:
         return {}
@@ -72,7 +72,7 @@ def store_registry_token(registry_url: str, token: str) -> None:
     tokens[registry_url.rstrip("/")] = token
     path = _registry_tokens_path()
     os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         json.dump(tokens, f, indent=2)
     try:
         os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
@@ -87,7 +87,7 @@ def remove_registry_token(registry_url: str) -> bool:
     if key not in tokens:
         return False
     del tokens[key]
-    with open(_registry_tokens_path(), "w") as f:
+    with open(_registry_tokens_path(), "w", encoding="utf-8") as f:
         json.dump(tokens, f, indent=2)
     return True
 
@@ -95,7 +95,7 @@ def remove_registry_token(registry_url: str) -> bool:
 def _read_credentials() -> dict:
     """Read the credentials file, or return empty dict."""
     try:
-        with open(_CREDENTIALS_FILE) as f:
+        with open(_CREDENTIALS_FILE, encoding="utf-8") as f:
             return json.load(f)
     except Exception:
         return {}
@@ -227,7 +227,7 @@ def is_authenticated() -> bool:
 def _write_credentials(creds: dict) -> None:
     """Write credentials dict to disk with restricted permissions."""
     os.makedirs(os.path.dirname(_CREDENTIALS_FILE), exist_ok=True)
-    with open(_CREDENTIALS_FILE, "w") as f:
+    with open(_CREDENTIALS_FILE, "w", encoding="utf-8") as f:
         json.dump(creds, f)
     try:
         os.chmod(_CREDENTIALS_FILE, stat.S_IRUSR | stat.S_IWUSR)  # 0o600

--- a/src/cartograph/blueprint_checkin.py
+++ b/src/cartograph/blueprint_checkin.py
@@ -35,7 +35,7 @@ def checkin_blueprint(carto, path: str, reason: str = "", version_bump: str = "m
         return {"status": "error", "message": "No blueprint.json found."}
 
     try:
-        with open(manifest_path) as f:
+        with open(manifest_path, encoding="utf-8") as f:
             data = json.load(f)
     except Exception as e:
         return {"status": "error", "message": f"Invalid blueprint.json: {e}"}
@@ -94,7 +94,7 @@ def checkin_blueprint(carto, path: str, reason: str = "", version_bump: str = "m
         baseline_manifest = os.path.join(dest_path, "blueprint.json")
         if os.path.isfile(baseline_manifest):
             try:
-                with open(baseline_manifest) as f:
+                with open(baseline_manifest, encoding="utf-8") as f:
                     baseline_data = json.load(f)
                 baseline_version = baseline_data.get("version")
             except Exception:
@@ -205,7 +205,7 @@ def checkin_blueprint(carto, path: str, reason: str = "", version_bump: str = "m
             validation_block["runtime"] = rv
     data["validation"] = validation_block
 
-    with open(manifest_path, "w") as f:
+    with open(manifest_path, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2)
 
     # --- Archive current library version to history/ ---
@@ -265,12 +265,12 @@ def checkin_blueprint(carto, path: str, reason: str = "", version_bump: str = "m
     changelog = []
     if os.path.exists(changelog_path):
         try:
-            with open(changelog_path) as f:
+            with open(changelog_path, encoding="utf-8") as f:
                 changelog = json.load(f)
         except Exception:
             pass
     changelog.insert(0, changelog_entry)
-    with open(changelog_path, "w") as f:
+    with open(changelog_path, "w", encoding="utf-8") as f:
         json.dump(changelog, f, indent=2)
 
     # --- Write fresh stamp at library path ---

--- a/src/cartograph/blueprint_deps.py
+++ b/src/cartograph/blueprint_deps.py
@@ -38,7 +38,7 @@ def _load_blueprint(blueprint_path: str) -> tuple[dict | None, dict | None]:
             ),
         }
     try:
-        with open(manifest_path) as f:
+        with open(manifest_path, encoding="utf-8") as f:
             return json.load(f), None
     except Exception as e:
         return None, {"status": "error", "message": f"Invalid blueprint.json: {e}"}
@@ -79,14 +79,14 @@ def _read_installed_widget(project_root: str, widget_id: str) -> tuple[dict | No
         )
     manifest_path = os.path.join(widget_dir, "widget.json")
     try:
-        with open(manifest_path) as f:
+        with open(manifest_path, encoding="utf-8") as f:
             return json.load(f), None
     except Exception as e:
         return None, f"Could not read installed widget manifest at {manifest_path}: {e}"
 
 
 def _write_manifest(blueprint_path: str, data: dict) -> None:
-    with open(os.path.join(blueprint_path, "blueprint.json"), "w") as f:
+    with open(os.path.join(blueprint_path, "blueprint.json"), "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2)
 
 

--- a/src/cartograph/blueprint_install.py
+++ b/src/cartograph/blueprint_install.py
@@ -168,7 +168,7 @@ def _resolve_blueprint(carto, blueprint_id, version):
             )}
         # Read the historical manifest to get its declared deps.
         try:
-            with open(os.path.join(hist, "blueprint.json")) as f:
+            with open(os.path.join(hist, "blueprint.json"), encoding="utf-8") as f:
                 raw = json.load(f)
         except OSError as e:
             return {"error": f"Could not read historical blueprint: {e}"}
@@ -272,7 +272,7 @@ def _scan_blueprint_pins(cg_root):
         if not os.path.isfile(bpath):
             continue
         try:
-            with open(bpath) as f:
+            with open(bpath, encoding="utf-8") as f:
                 data = json.load(f)
         except (OSError, json.JSONDecodeError):
             continue
@@ -289,7 +289,7 @@ def _read_widget_version(widget_dir):
     if not os.path.isfile(wpath):
         return None
     try:
-        with open(wpath) as f:
+        with open(wpath, encoding="utf-8") as f:
             data = json.load(f)
     except (OSError, json.JSONDecodeError):
         return None

--- a/src/cartograph/blueprint_publish.py
+++ b/src/cartograph/blueprint_publish.py
@@ -55,7 +55,7 @@ def publish_blueprint(carto, path: str, *, dry_run: bool = False) -> dict:
         return {"status": "error", "message": "No blueprint.json found."}
 
     try:
-        with open(manifest_path) as f:
+        with open(manifest_path, encoding="utf-8") as f:
             manifest = json.load(f)
     except (OSError, json.JSONDecodeError) as e:
         return {"status": "error", "message": f"Invalid blueprint.json: {e}"}

--- a/src/cartograph/blueprint_status.py
+++ b/src/cartograph/blueprint_status.py
@@ -32,7 +32,7 @@ def blueprint_status(carto, blueprint_id, target_dir):
         return {"error": f"'{blueprint_id}' not found at {bp_path}."}
 
     try:
-        with open(manifest) as f:
+        with open(manifest, encoding="utf-8") as f:
             data = json.load(f)
     except (OSError, json.JSONDecodeError) as e:
         return {"error": f"Failed to read blueprint manifest: {e}"}
@@ -100,7 +100,7 @@ def orphan_leaves(target_dir):
         if os.path.isfile(bjson):
             has_blueprint = True
             try:
-                with open(bjson) as f:
+                with open(bjson, encoding="utf-8") as f:
                     data = json.load(f)
                 for d in data.get("dependencies", []) or []:
                     if isinstance(d, dict) and d.get("id"):
@@ -109,7 +109,7 @@ def orphan_leaves(target_dir):
                 continue
         elif os.path.isfile(wjson):
             try:
-                with open(wjson) as f:
+                with open(wjson, encoding="utf-8") as f:
                     data = json.load(f)
                 wid = (data.get("meta") or data).get("id")
                 if wid:
@@ -144,7 +144,7 @@ def all_blueprint_status(carto, target_dir):
         if not os.path.isfile(bjson):
             continue
         try:
-            with open(bjson) as f:
+            with open(bjson, encoding="utf-8") as f:
                 bp_id = json.load(f).get("id")
         except (OSError, json.JSONDecodeError):
             continue
@@ -165,7 +165,7 @@ def _read_widget_version(widget_dir):
     if not os.path.isfile(wjson):
         return None
     try:
-        with open(wjson) as f:
+        with open(wjson, encoding="utf-8") as f:
             data = json.load(f)
     except (OSError, json.JSONDecodeError):
         return None

--- a/src/cartograph/blueprint_validator.py
+++ b/src/cartograph/blueprint_validator.py
@@ -117,7 +117,7 @@ def validate_blueprint(carto, path: str) -> dict:
                 "message": f"examples/ contains no .{ext} files"}
     example_file = examples_in_lang[0]
     example_path = os.path.join(example_dir, example_file)
-    example_content = open(example_path).read()
+    example_content = open(example_path, encoding="utf-8").read()
     if "[TODO]" in example_content:
         return {
             "status": "error",
@@ -272,7 +272,7 @@ def _read_widget_meta(widget_dir: str | None) -> dict | None:
     if not os.path.isfile(wjson):
         return None
     try:
-        with open(wjson) as f:
+        with open(wjson, encoding="utf-8") as f:
             return json.load(f)
     except Exception:
         return None
@@ -300,7 +300,7 @@ def _scan_project_cg(blueprint_path: str) -> dict:
         if not os.path.isfile(wjson):
             continue
         try:
-            with open(wjson) as f:
+            with open(wjson, encoding="utf-8") as f:
                 data = json.load(f)
         except Exception:
             continue
@@ -361,7 +361,7 @@ def _collect_runtime_deps(dep_sources: dict[str, str]) -> list[str]:
         if not os.path.isfile(widget_json):
             continue
         try:
-            with open(widget_json) as f:
+            with open(widget_json, encoding="utf-8") as f:
                 data = json.load(f)
         except Exception as e:
             log.debug("Could not read %s for pip deps: %s", widget_json, e)

--- a/src/cartograph/checkin.py
+++ b/src/cartograph/checkin.py
@@ -58,7 +58,7 @@ def _restore_library_notes(manifest_path: str) -> None:
     Called just before copying to the library so agents cannot drift or
     remove the library-wide standards even if they edited widget.json.
     """
-    with open(manifest_path) as f:
+    with open(manifest_path, encoding="utf-8") as f:
         data = json.load(f)
     language = data.get("tech_stack", {}).get("language", "")
     if isinstance(language, list):
@@ -67,7 +67,7 @@ def _restore_library_notes(manifest_path: str) -> None:
     canonical = _canonical_library_notes(language, domain)
     if canonical:
         data["library_notes"] = canonical
-        with open(manifest_path, "w") as f:
+        with open(manifest_path, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2)
 
 
@@ -109,7 +109,7 @@ def _lookup_cloud_baseline(path: str, item_id: str,
         if not os.path.isfile(sidecar_path):
             return None
     try:
-        with open(sidecar_path) as f:
+        with open(sidecar_path, encoding="utf-8") as f:
             source = json.load(f)
     except Exception:
         return None
@@ -176,7 +176,7 @@ def checkin(carto, path: str, reason: str = "", version_bump: str = "minor",
         return {"status": "error", "message": "No widget.json found."}
 
     try:
-        with open(manifest_path) as f:
+        with open(manifest_path, encoding="utf-8") as f:
             data = json.load(f)
     except Exception as e:
         return {"status": "error", "message": f"Invalid widget.json: {e}"}
@@ -250,7 +250,7 @@ def checkin(carto, path: str, reason: str = "", version_bump: str = "minor",
                 elif widget_record is not None:
                     lib_manifest = os.path.join(widget_record["path"], "widget.json")
                     try:
-                        with open(lib_manifest) as f:
+                        with open(lib_manifest, encoding="utf-8") as f:
                             baseline_manifest = json.load(f)
                     except Exception:
                         baseline_manifest = None
@@ -328,7 +328,7 @@ def checkin(carto, path: str, reason: str = "", version_bump: str = "minor",
             validation_block["runtime"] = rv
     data["validation"] = validation_block
 
-    with open(manifest_path, "w") as f:
+    with open(manifest_path, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2)
 
     # --- Determine destination ---
@@ -406,12 +406,12 @@ def checkin(carto, path: str, reason: str = "", version_bump: str = "minor",
     changelog = []
     if os.path.exists(changelog_path):
         try:
-            with open(changelog_path) as f:
+            with open(changelog_path, encoding="utf-8") as f:
                 changelog = json.load(f)
         except Exception:
             pass
     changelog.insert(0, changelog_entry)
-    with open(changelog_path, "w") as f:
+    with open(changelog_path, "w", encoding="utf-8") as f:
         json.dump(changelog, f, indent=2)
 
     # --- Diff for AI review ---
@@ -478,10 +478,10 @@ def restore(carto, item_id, version, reason):
     # passes, then checkin() bumps it normally (patch).
     current_version = item.get("version", "1.0.0")
     manifest_path = os.path.join(temp_dir, "widget.json")
-    with open(manifest_path) as f:
+    with open(manifest_path, encoding="utf-8") as f:
         manifest = json.load(f)
     manifest["meta"]["version"] = current_version
-    with open(manifest_path, "w") as f:
+    with open(manifest_path, "w", encoding="utf-8") as f:
         json.dump(manifest, f, indent=2)
 
     result = checkin(carto, temp_dir, reason=f"RESTORE from v{version}: {reason}",
@@ -521,13 +521,13 @@ def write_review(widget_path: str, score: float, version: str,
     reviews_data = {"reviews": []}
     if os.path.exists(review_path):
         try:
-            with open(review_path) as f:
+            with open(review_path, encoding="utf-8") as f:
                 reviews_data = json.load(f)
         except Exception:
             pass
 
     reviews_data["reviews"].append(entry)
-    with open(review_path, "w") as f:
+    with open(review_path, "w", encoding="utf-8") as f:
         json.dump(reviews_data, f, indent=2)
 
     avg = sum(r["rating"] for r in reviews_data["reviews"]) / len(reviews_data["reviews"])
@@ -614,7 +614,7 @@ def widget_status(carto, widget_id, target_dir, check_cloud=True):
         return {"error": f"'{library_id}' not found in library."}
 
     try:
-        with open(os.path.join(installed_path, "widget.json")) as f:
+        with open(os.path.join(installed_path, "widget.json"), encoding="utf-8") as f:
             installed_version = json.load(f).get("meta", {}).get("version", "unknown")
     except Exception as e:
         return {"error": f"Failed to read installed manifest: {e}"}

--- a/src/cartograph/cli.py
+++ b/src/cartograph/cli.py
@@ -190,6 +190,16 @@ def _search_registries(query, domain_filter, language_filter, top_k,
     allowlist = set(registry_filter) if registry_filter else None
     owner_bare = owner_filter.lstrip("@") if owner_filter else None
 
+    # When show-unavailable is off, scope cloud results to the languages this
+    # machine actually has. The set is sent to the server so it filters BEFORE
+    # ranking/truncating (so top_k fills with installable widgets), and is
+    # reused below as a client-side backstop for servers that ignore the param.
+    from .config import load_config
+    avail = None
+    if not load_config().get("library", {}).get("show_unavailable", True):
+        from .languages import available_languages
+        avail = available_languages()
+
     all_widgets = []
     errors = {}
     scoped_prefixes = []
@@ -199,7 +209,8 @@ def _search_registries(query, domain_filter, language_filter, top_k,
             return []
         scoped_prefixes.append(prefix)
         result = cloud_search(query, domain_filter, language_filter,
-                              top_k=top_k, registry_url=registry_url)
+                              top_k=top_k, registry_url=registry_url,
+                              languages=avail)
         if result.get("error"):
             errors[prefix] = result["error"]
         widgets = []
@@ -237,6 +248,16 @@ def _search_registries(query, domain_filter, language_filter, top_k,
         unknown = allowlist - set(scoped_prefixes)
         for prefix in unknown:
             errors[prefix] = f"Unknown registry prefix {prefix!r}. Run `cartograph registry` to list."
+
+    # Client-side backstop: the server is asked to filter to `avail` (see
+    # above), but a registry that doesn't honor the `languages` param would
+    # still return unavailable-language rows. Re-filter here so show-unavailable
+    # is enforced regardless of server behavior. Local results get the
+    # equivalent filter at library-load time (engine._load_library).
+    if avail is not None:
+        from .engine import normalize_language
+        all_widgets = [w for w in all_widgets
+                       if normalize_language(w.get("language", "")) in avail]
 
     return all_widgets, errors, scoped_prefixes
 

--- a/src/cartograph/cli.py
+++ b/src/cartograph/cli.py
@@ -127,7 +127,7 @@ def _preflight_from_path(path: str) -> None:
     if not os.path.isfile(manifest):
         return  # command itself will report the missing file
     try:
-        with open(manifest) as f:
+        with open(manifest, encoding="utf-8") as f:
             language = json.load(f).get("tech_stack", {}).get("language", "python")
         _preflight_language(language)
     except json.JSONDecodeError:
@@ -492,7 +492,7 @@ def _resolve_installed_widget(widget_dir: str, default_target: str):
     if os.path.isfile(bp_manifest):
         manifest = bp_manifest
         try:
-            with open(manifest) as f:
+            with open(manifest, encoding="utf-8") as f:
                 canonical_id = json.load(f).get("id", "")
             if not canonical_id:
                 err({"error": f"blueprint.json at {manifest} is missing id"})
@@ -501,7 +501,7 @@ def _resolve_installed_widget(widget_dir: str, default_target: str):
     else:
         manifest = w_manifest
         try:
-            with open(manifest) as f:
+            with open(manifest, encoding="utf-8") as f:
                 canonical_id = json.load(f).get("meta", {}).get("id", "")
             if not canonical_id:
                 err({"error": f"widget.json at {manifest} is missing meta.id"})
@@ -749,7 +749,7 @@ def _read_source_meta(install_path: str) -> dict | None:
     if not os.path.isfile(sidecar):
         return None
     try:
-        with open(sidecar) as f:
+        with open(sidecar, encoding="utf-8") as f:
             return json.load(f)
     except Exception:
         return None
@@ -854,7 +854,7 @@ def _force_push(checkin_result: dict, install_path: str | None = None,
             published_governance = push_result.get("governance")
             if published_governance:
                 sidecar["governance"] = published_governance
-            with open(os.path.join(widget_path, ".cartograph_source"), "w") as _f:
+            with open(os.path.join(widget_path, ".cartograph_source"), "w", encoding="utf-8") as _f:
                 json.dump(sidecar, _f)
             # One-line governance reminder on every cloud write. Keeps the
             # author aware of which model their widget ships under without
@@ -1454,7 +1454,7 @@ def cmd_cloud_publish(args):
                     path = lib_widget["path"]
         if not widget_id:
             try:
-                with open(os.path.join(path, "widget.json")) as f:
+                with open(os.path.join(path, "widget.json"), encoding="utf-8") as f:
                     data = json.load(f)
                 widget_id = data.get("meta", {}).get("id") or data.get("id")
             except Exception:
@@ -1466,7 +1466,7 @@ def cmd_cloud_publish(args):
 
     # Read widget.json once for stamp check + contamination scan
     try:
-        with open(os.path.join(path, "widget.json")) as f:
+        with open(os.path.join(path, "widget.json"), encoding="utf-8") as f:
             widget_data = json.load(f)
     except Exception:
         widget_data = {}
@@ -1655,7 +1655,7 @@ def cmd_cloud_adopt(args):
     sidecar_path = os.path.join(widget["path"], ".cartograph_source")
     if os.path.exists(sidecar_path) and not args.force:
         try:
-            with open(sidecar_path) as f:
+            with open(sidecar_path, encoding="utf-8") as f:
                 existing = json.load(f)
             err({
                 "error": (
@@ -1666,7 +1666,7 @@ def cmd_cloud_adopt(args):
             })
         except Exception:
             pass  # unreadable sidecar - overwrite it
-    with open(sidecar_path, "w") as f:
+    with open(sidecar_path, "w", encoding="utf-8") as f:
         json.dump(sidecar, f)
 
     cloud_ver = cloud_widget.get("version", "?")
@@ -1785,7 +1785,7 @@ def cmd_rollback(args):
         local_w = next((w for w in carto.widgets if w["id"] == base_id), None)
         if local_w:
             try:
-                with open(os.path.join(local_w["path"], ".cartograph_source")) as f:
+                with open(os.path.join(local_w["path"], ".cartograph_source"), encoding="utf-8") as f:
                     local_sidecar = json.load(f)
             except Exception:
                 pass
@@ -1968,7 +1968,7 @@ def cmd_rules(args):
         filepath = os.path.join(_rules_dir_for_scope(scope), filename)
         if not os.path.exists(filepath):
             err({"error": f"No rules file at {filepath}. Run 'cartograph rules init --language {language}" + (" --global" if scope == "global" else "") + "' to create one."})
-        with open(filepath) as f:
+        with open(filepath, encoding="utf-8") as f:
             content = f.read()
         if as_json:
             out({"status": "success", "language": language, "scope": scope, "path": filepath, "content": content})
@@ -1991,7 +1991,7 @@ def cmd_rules(args):
             err({"error": f"No rules support for language '{language}'"})
         if from_file:
             try:
-                with open(from_file) as f:
+                with open(from_file, encoding="utf-8") as f:
                     content = f.read()
             except OSError as e:
                 err({"error": f"Could not read {from_file}: {e}"})
@@ -2008,7 +2008,7 @@ def cmd_rules(args):
         if os.path.exists(filepath) and not confirm:
             err({"error": f"Rules file already exists at {filepath}. Re-run with --confirm to overwrite."})
         os.makedirs(rules_dir, exist_ok=True)
-        with open(filepath, "w") as f:
+        with open(filepath, "w", encoding="utf-8") as f:
             f.write(content)
         if as_json:
             out({"status": "success", "language": language, "scope": scope, "path": filepath, "bytes": len(content)})
@@ -2038,7 +2038,7 @@ def cmd_rules(args):
             err({"error": f"This would overwrite your custom rules at {filepath}. Re-run with --confirm to proceed."})
 
         template = get_template(language)
-        with open(filepath, "w") as f:
+        with open(filepath, "w", encoding="utf-8") as f:
             f.write(template)
 
         if as_json:
@@ -2069,7 +2069,7 @@ def cmd_rules(args):
 
         already_existed = os.path.exists(filepath)
         if not already_existed:
-            with open(filepath, "w") as f:
+            with open(filepath, "w", encoding="utf-8") as f:
                 f.write(template)
 
         if as_json:
@@ -2163,7 +2163,7 @@ def cmd_workflow(args):
     path = os.path.join(workflows_dir, f"{name}.md")
     if not os.path.isfile(path):
         err({"error": f"Workflow '{name}' not found. Run 'cartograph workflow' to list."})
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         print(f"\n{f.read()}")
 
 
@@ -2308,7 +2308,7 @@ def _build_setup_instructions() -> str:
     import json as _json
     _cfg_path = os.path.join(os.path.dirname(__file__), "library_config.json")
     try:
-        with open(_cfg_path) as _f:
+        with open(_cfg_path, encoding="utf-8") as _f:
             cfg = _json.load(_f)
     except Exception:
         cfg = {}
@@ -2630,7 +2630,7 @@ def cmd_import(args):
         if not os.path.isfile(manifest_path):
             continue
         try:
-            with open(manifest_path) as f:
+            with open(manifest_path, encoding="utf-8") as f:
                 data = json.load(f)
             language = data.get("tech_stack", {}).get("language", "unknown")
             if isinstance(language, list):
@@ -2705,7 +2705,7 @@ def _quarantine_widget(widget_path: str, quarantine_dir: str, reason: str) -> No
         # will still flag it.
         return
     try:
-        with open(os.path.join(dest, ".quarantine_reason"), "w") as f:
+        with open(os.path.join(dest, ".quarantine_reason"), "w", encoding="utf-8") as f:
             f.write(reason + "\n")
     except OSError:
         pass
@@ -2909,7 +2909,7 @@ def _resolve_workflow(workflow_arg):
         else:
             msg += f" Create it at: {workflows_dir}/{workflow_arg}.md"
         err({"error": msg})
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         return "\n" + f.read()
 
 
@@ -2973,7 +2973,7 @@ def cmd_setup(args):
     marker = "## Cartograph"
     workflow_marker = "### Workflow"
     if os.path.exists(filepath):
-        with open(filepath) as f:
+        with open(filepath, encoding="utf-8") as f:
             existing = f.read()
         if marker in existing:
             if getattr(args, "overwrite", False):
@@ -2993,14 +2993,14 @@ def cmd_setup(args):
                     overwrite_content = content
                     workflow_note = ""
                 new_file = _replace_cartograph_section(existing, overwrite_content)
-                with open(filepath, "w") as f:
+                with open(filepath, "w", encoding="utf-8") as f:
                     f.write(new_file)
                 print(f"\n  Replaced ## Cartograph section in {filepath}{workflow_note}")
                 return
             # Section exists - check if user is just adding workflow
             workflow_content = _resolve_workflow(getattr(args, "workflow", None))
             if workflow_content and workflow_marker not in existing:
-                with open(filepath, "a") as f:
+                with open(filepath, "a", encoding="utf-8") as f:
                     f.write("\n" + workflow_content)
                 print(f"\n  Added workflow to existing Cartograph section in {filepath}")
                 return
@@ -3010,7 +3010,7 @@ def cmd_setup(args):
             print(f"  Pass --overwrite to replace the existing section with a fresh one.\n")
             return
 
-    with open(filepath, "a") as f:
+    with open(filepath, "a", encoding="utf-8") as f:
         f.write("\n" + content)
 
     if detected_reason:

--- a/src/cartograph/cloud.py
+++ b/src/cartograph/cloud.py
@@ -194,9 +194,17 @@ def _validate_widgets(widgets: list, context: str = "") -> list:
           summary="Search the widget registry")
 def search(query: str, domain_filter: str | None = None,
            language_filter: str | None = None, top_k: int = 10,
-           registry_url: str | None = None) -> dict:
+           registry_url: str | None = None,
+           languages: "set[str] | None" = None) -> dict:
     """
     Search the cloud registry (public — no auth required).
+
+    `language_filter` is the single-language `--language` narrowing.
+    `languages`, if given, is the set of languages available on this
+    machine (from `doctor`/`available_languages()`); the server filters
+    results to that set BEFORE ranking and truncating to top_k, so the
+    page fills with installable widgets. The caller still re-filters
+    client-side as a backstop for servers that don't honor the param.
 
     Returns {"widgets": [...], "source": "cloud"} on success,
     or {"error": ..., "widgets": []} on failure so the caller can still
@@ -207,6 +215,9 @@ def search(query: str, domain_filter: str | None = None,
         params += f"&domain={urllib.parse.quote(domain_filter)}"
     if language_filter:
         params += f"&language={urllib.parse.quote(language_filter)}"
+    if languages:
+        # Sorted for stable URLs (cache-friendly); server treats it as a set.
+        params += f"&languages={urllib.parse.quote(','.join(sorted(languages)))}"
 
     result = _get(f"/v1/widgets/search{params}", registry_url=registry_url)
     if "error" in result:

--- a/src/cartograph/config.py
+++ b/src/cartograph/config.py
@@ -311,7 +311,7 @@ def _write_toml(path: str, config: dict):
             elif isinstance(v, (int, float)):
                 lines.append(f"{k} = {v}")
         lines.append("")
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         f.write("\n".join(lines))
 
 
@@ -327,7 +327,7 @@ def _registries_path() -> str:
 def get_registries() -> list[dict]:
     """Return user-configured registries (excludes the public Cartograph registry)."""
     try:
-        with open(_registries_path()) as f:
+        with open(_registries_path(), encoding="utf-8") as f:
             return json.load(f)
     except Exception:
         return []
@@ -336,7 +336,7 @@ def get_registries() -> list[dict]:
 def _save_registries(registries: list[dict]) -> None:
     path = _registries_path()
     os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         json.dump(registries, f, indent=2)
 
 

--- a/src/cartograph/contamination.py
+++ b/src/cartograph/contamination.py
@@ -49,7 +49,7 @@ def _scan_widget_contamination(path: str) -> dict:
     """Widget pipeline (unchanged): delegate to language engine."""
     manifest_path = os.path.join(path, "widget.json")
     try:
-        with open(manifest_path) as f:
+        with open(manifest_path, encoding="utf-8") as f:
             data = json.load(f)
     except Exception as e:
         return {

--- a/src/cartograph/dashboard.py
+++ b/src/cartograph/dashboard.py
@@ -30,7 +30,7 @@ def _load_config():
     cf = _config_file()
     if os.path.exists(cf):
         try:
-            with open(cf) as f:
+            with open(cf, encoding="utf-8") as f:
                 return json.load(f)
         except Exception:
             pass
@@ -39,7 +39,7 @@ def _load_config():
 
 def _save_config(cfg):
     os.makedirs(_state_dir(), exist_ok=True)
-    with open(_config_file(), "w") as f:
+    with open(_config_file(), "w", encoding="utf-8") as f:
         json.dump(cfg, f, indent=2)
 
 
@@ -145,14 +145,14 @@ def _make_handler(engine):
             if not os.path.exists(review_path):
                 return {"error": "No reviews file"}
             try:
-                with open(review_path) as f:
+                with open(review_path, encoding="utf-8") as f:
                     reviews_data = json.load(f)
                 reviews = reviews_data.get("reviews", [])
                 if index >= len(reviews):
                     return {"error": "Invalid review index"}
                 reviews.pop(index)
                 reviews_data["reviews"] = reviews
-                with open(review_path, "w") as f:
+                with open(review_path, "w", encoding="utf-8") as f:
                     json.dump(reviews_data, f, indent=2)
                 avg = round(sum(r["rating"] for r in reviews) / len(reviews), 1) if reviews else 0
                 return {"status": "success", "avg_rating": avg}
@@ -298,7 +298,7 @@ def _make_handler(engine):
             changelog_path = os.path.join(widget["path"], "changelog.json")
             if os.path.isfile(changelog_path):
                 try:
-                    with open(changelog_path) as f:
+                    with open(changelog_path, encoding="utf-8") as f:
                         changelog = _json.load(f)
                 except Exception:
                     pass
@@ -345,7 +345,7 @@ def _make_handler(engine):
                         if size > max_size:
                             files[relpath] = f"[File too large: {size} bytes]"
                             continue
-                        with open(fpath, "r", errors="replace") as f:
+                        with open(fpath, "r", errors="replace", encoding="utf-8") as f:
                             files[relpath] = f.read()
                     except Exception:
                         files[relpath] = "[Could not read file]"
@@ -382,7 +382,7 @@ def _make_handler(engine):
 
 def _write_pid(pid, port):
     os.makedirs(_state_dir(), exist_ok=True)
-    with open(_pid_file(), "w") as f:
+    with open(_pid_file(), "w", encoding="utf-8") as f:
         f.write(f"{pid}\n{port}\n")
 
 
@@ -423,7 +423,7 @@ def _read_pid():
     if not os.path.exists(pf):
         return None, None
     try:
-        lines = open(pf).read().strip().splitlines()
+        lines = open(pf, encoding="utf-8").read().strip().splitlines()
         pid = int(lines[0])
         port = int(lines[1]) if len(lines) > 1 else 0
         if not _is_pid_alive(pid):

--- a/src/cartograph/engine.py
+++ b/src/cartograph/engine.py
@@ -114,7 +114,7 @@ def _ensure_global_rules() -> None:
                 continue
             filepath = os.path.join(rules_dir, filename)
             if not os.path.exists(filepath):
-                with open(filepath, "w") as f:
+                with open(filepath, "w", encoding="utf-8") as f:
                     f.write(template)
     except Exception as e:
         log.debug("Could not create global rules templates: %s", e)
@@ -221,7 +221,7 @@ def find_installed_widget_dir(cg_root: str, canonical_id: str) -> str | None:
         if not os.path.isfile(wjson):
             continue
         try:
-            with open(wjson) as f:
+            with open(wjson, encoding="utf-8") as f:
                 data = json.load(f)
         except (OSError, json.JSONDecodeError):
             continue
@@ -336,15 +336,15 @@ class Cartograph:
 
             if in_lib and not in_local:
                 files_removed.append(rel)
-                lib_lines = open(lib_files[rel]).readlines()
+                lib_lines = open(lib_files[rel], encoding="utf-8").readlines()
                 diff_parts.extend(difflib.unified_diff(lib_lines, [], fromfile=f"a/{rel}", tofile=f"b/{rel}"))
             elif in_local and not in_lib:
                 files_added.append(rel)
-                local_lines = open(local_files[rel]).readlines()
+                local_lines = open(local_files[rel], encoding="utf-8").readlines()
                 diff_parts.extend(difflib.unified_diff([], local_lines, fromfile=f"a/{rel}", tofile=f"b/{rel}"))
             else:
-                lib_lines = open(lib_files[rel]).readlines()
-                local_lines = open(local_files[rel]).readlines()
+                lib_lines = open(lib_files[rel], encoding="utf-8").readlines()
+                local_lines = open(local_files[rel], encoding="utf-8").readlines()
                 file_diff = list(difflib.unified_diff(lib_lines, local_lines, fromfile=f"a/{rel}", tofile=f"b/{rel}"))
                 if file_diff:
                     files_changed.append(rel)
@@ -378,7 +378,7 @@ class Cartograph:
             return {"rating": 0, "count": 0, "trend": None, "reviews": [], "version_averages": {}}
         
         try:
-            with open(review_path, 'r') as f:
+            with open(review_path, 'r', encoding="utf-8") as f:
                 data = json.load(f)
                 reviews = data.get("reviews", [])
                 if not reviews:
@@ -454,7 +454,7 @@ class Cartograph:
         if not os.path.exists(INSTALL_STATS_PATH):
             return {}
         try:
-            with open(INSTALL_STATS_PATH, 'r') as f:
+            with open(INSTALL_STATS_PATH, 'r', encoding="utf-8") as f:
                 data = json.load(f)
                 return data.get("installs", {})
         except (OSError, json.JSONDecodeError):
@@ -464,7 +464,7 @@ class Cartograph:
         os.makedirs(CARTOGRAPH_DIR, exist_ok=True)
         temp_path = INSTALL_STATS_PATH + ".tmp"
         try:
-            with open(temp_path, 'w') as f:
+            with open(temp_path, 'w', encoding="utf-8") as f:
                 json.dump({"installs": self.install_stats}, f, indent=2)
             os.replace(temp_path, INSTALL_STATS_PATH)
         except Exception as e:
@@ -493,7 +493,7 @@ class Cartograph:
         if not os.path.exists(LIBRARY_CACHE_PATH):
             return {}
         try:
-            with open(LIBRARY_CACHE_PATH, 'r') as f:
+            with open(LIBRARY_CACHE_PATH, 'r', encoding="utf-8") as f:
                 return json.load(f)
         except (OSError, json.JSONDecodeError):
             return {}
@@ -503,7 +503,7 @@ class Cartograph:
         os.makedirs(CARTOGRAPH_DIR, exist_ok=True)
         temp_path = LIBRARY_CACHE_PATH + ".tmp"
         try:
-            with open(temp_path, 'w') as f:
+            with open(temp_path, 'w', encoding="utf-8") as f:
                 json.dump(cache, f)
             os.replace(temp_path, LIBRARY_CACHE_PATH)
         except OSError as e:
@@ -539,7 +539,7 @@ class Cartograph:
         found = [p for p in glob.glob(search_pattern, recursive=True) if "history" not in p]
         for manifest_path in found:
             try:
-                with open(manifest_path, 'r') as f:
+                with open(manifest_path, 'r', encoding="utf-8") as f:
                     data = json.load(f)
                 meta = data.get('meta', data)
 
@@ -609,7 +609,7 @@ class Cartograph:
                     if os.path.exists(src_dir):
                         for src_file in glob.glob(os.path.join(src_dir, "*.*")):
                             try:
-                                total_lines += len(open(src_file).read().splitlines())
+                                total_lines += len(open(src_file, encoding="utf-8").read().splitlines())
                             except (OSError, UnicodeDecodeError):
                                 pass
 
@@ -681,7 +681,7 @@ class Cartograph:
                  if "history" not in p]
         for manifest_path in found:
             try:
-                with open(manifest_path, 'r') as f:
+                with open(manifest_path, 'r', encoding="utf-8") as f:
                     data = json.load(f)
                 bp_path = os.path.dirname(manifest_path)
                 bp_id = data.get('id', os.path.basename(bp_path))

--- a/src/cartograph/inspector.py
+++ b/src/cartograph/inspector.py
@@ -41,7 +41,7 @@ def _read_dir(dirpath, prefix_filter=None):
             if prefix_filter and not name.startswith(prefix_filter):
                 continue
             try:
-                with open(fpath) as f:
+                with open(fpath, encoding="utf-8") as f:
                     out[name] = f.read()
             except Exception as e:
                 out[name] = f"Error reading: {e}"
@@ -89,7 +89,7 @@ def inspect(carto, widget_id, show_source=False, show_all_versions=False,
     review_data = carto._load_reviews(widget_path)
 
     try:
-        with open(os.path.join(read_path, "widget.json")) as f:
+        with open(os.path.join(read_path, "widget.json"), encoding="utf-8") as f:
             manifest = json.load(f)
     except (OSError, json.JSONDecodeError):
         manifest = {}
@@ -145,7 +145,7 @@ def inspect_blueprint(carto, blueprint_id, show_source=False,
         read_path = bp_path
 
     try:
-        with open(os.path.join(read_path, "blueprint.json")) as f:
+        with open(os.path.join(read_path, "blueprint.json"), encoding="utf-8") as f:
             manifest = json.load(f)
     except (OSError, json.JSONDecodeError):
         manifest = {}

--- a/src/cartograph/installer.py
+++ b/src/cartograph/installer.py
@@ -130,7 +130,7 @@ def _install_from_cloud(widget_id, dest_path, registry_url=None, owner_hint=None
         }
         if governance:
             source_meta["governance"] = governance
-        with open(os.path.join(dest_path, ".cartograph_source"), "w") as f:
+        with open(os.path.join(dest_path, ".cartograph_source"), "w", encoding="utf-8") as f:
             json.dump(source_meta, f)
 
         return {
@@ -203,7 +203,7 @@ def install(carto, widget_id, target_dir, version=None,
         local_widget = next((w for w in carto.widgets if w["id"] == bare_id), None)
         if local_widget:
             try:
-                with open(os.path.join(local_widget["path"], ".cartograph_source")) as f:
+                with open(os.path.join(local_widget["path"], ".cartograph_source"), encoding="utf-8") as f:
                     sidecar = json.load(f)
                 sidecar_reg = (sidecar.get("registry_url") or _PUBLIC_REGISTRY_URL).rstrip("/")
                 target_reg = (registry_url or _PUBLIC_REGISTRY_URL).rstrip("/")
@@ -279,14 +279,14 @@ def upgrade(carto, widget_id, target_dir, version=None):
     # Read current version and sidecar before removing
     old_version = "unknown"
     try:
-        with open(os.path.join(dest_path, "widget.json")) as f:
+        with open(os.path.join(dest_path, "widget.json"), encoding="utf-8") as f:
             old_version = json.load(f).get("meta", {}).get("version", "unknown")
     except Exception:
         pass
 
     source_meta = {}
     try:
-        with open(os.path.join(dest_path, ".cartograph_source")) as f:
+        with open(os.path.join(dest_path, ".cartograph_source"), encoding="utf-8") as f:
             source_meta = json.load(f)
     except Exception:
         pass
@@ -440,7 +440,7 @@ def rename_widget(carto, old_id: str, new_name: str | None,
 
     manifest_path = os.path.join(old_dir, "widget.json")
     try:
-        with open(manifest_path) as f:
+        with open(manifest_path, encoding="utf-8") as f:
             data = json.load(f)
     except Exception as e:
         return {"status": "error", "message": f"Could not read widget.json: {e}"}
@@ -503,12 +503,12 @@ def _rewrite_widget_dir(path: str, new_id: str, new_domain: str,
                         old_module: str, new_module: str) -> None:
     """Update widget.json and rename Python module files + imports in-place."""
     manifest_path = os.path.join(path, "widget.json")
-    with open(manifest_path) as f:
+    with open(manifest_path, encoding="utf-8") as f:
         data = json.load(f)
     meta = data.setdefault("meta", {})
     meta["id"] = new_id
     meta["domain"] = new_domain
-    with open(manifest_path, "w") as f:
+    with open(manifest_path, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2)
 
     # Invalidate validation stamp — contents have changed.
@@ -550,11 +550,11 @@ def _rename_python_module(path: str, old_module: str, new_module: str) -> None:
     ):
         if not os.path.isfile(fpath):
             continue
-        with open(fpath) as f:
+        with open(fpath, encoding="utf-8") as f:
             text = f.read()
         new_text = from_rel.sub(rf"\1{new_module}\2", text)
         new_text = from_abs.sub(rf"\1{new_module}\2", new_text)
         new_text = import_abs.sub(rf"\1{new_module}\2", new_text)
         if new_text != text:
-            with open(fpath, "w") as f:
+            with open(fpath, "w", encoding="utf-8") as f:
                 f.write(new_text)

--- a/src/cartograph/languages/angular.py
+++ b/src/cartograph/languages/angular.py
@@ -207,7 +207,7 @@ def _sub(template: str, module: str = "", class_name: str = "", display: str = "
 
 def _write(path: str, content: str) -> None:
     os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         f.write(content)
 
 
@@ -395,7 +395,7 @@ class AngularEngine(LanguageEngine):
             ("tsconfig.spec.json", tsconfig_spec_json),
             ("ng-package.json", ng_package_json),
         ]:
-            with open(os.path.join(target_dir, filename), "w") as f:
+            with open(os.path.join(target_dir, filename), "w", encoding="utf-8") as f:
                 json.dump(obj, f, indent=2)
                 f.write("\n")
 
@@ -473,7 +473,7 @@ class AngularEngine(LanguageEngine):
     def install_deps(self, path: str, dependencies: list) -> None:
         package_json_path = os.path.join(path, "package.json")
         if os.path.exists(package_json_path) and dependencies:
-            with open(package_json_path) as f:
+            with open(package_json_path, encoding="utf-8") as f:
                 pkg = json.load(f)
             changed = False
             for dep in dependencies:
@@ -488,7 +488,7 @@ class AngularEngine(LanguageEngine):
                     pkg.setdefault("dependencies", {})[bare] = ver_part
                     changed = True
             if changed:
-                with open(package_json_path, "w") as f:
+                with open(package_json_path, "w", encoding="utf-8") as f:
                     json.dump(pkg, f, indent=2)
                     f.write("\n")
 
@@ -605,7 +605,7 @@ class AngularEngine(LanguageEngine):
         """Read the first project name from angular.json."""
         angular_json = os.path.join(path, "angular.json")
         try:
-            with open(angular_json) as f:
+            with open(angular_json, encoding="utf-8") as f:
                 config = json.load(f)
             return next(iter(config.get("projects", {})), None)
         except Exception:

--- a/src/cartograph/languages/base.py
+++ b/src/cartograph/languages/base.py
@@ -266,7 +266,7 @@ class LanguageEngine:
             rel = os.path.relpath(fpath, path)
             is_src = fpath in src_files
             try:
-                code = open(fpath).read()
+                code = open(fpath, encoding="utf-8").read()
             except Exception as e:
                 blocks.append(f"Could not read source file {rel}: {e}")
                 continue
@@ -441,11 +441,11 @@ class LanguageEngine:
             f"# consume only what src/ exposes - no direct cg/ imports past\n"
             f"# this sealed surface.\n"
         )
-        with open(os.path.join(src, f"{module_name}.{ext}"), "w") as f:
+        with open(os.path.join(src, f"{module_name}.{ext}"), "w", encoding="utf-8") as f:
             f.write(marker)
-        with open(os.path.join(tests, f"test_{module_name}.{ext}"), "w") as f:
+        with open(os.path.join(tests, f"test_{module_name}.{ext}"), "w", encoding="utf-8") as f:
             f.write(f"# [TODO] Test the {display_name} blueprint surface.\n")
-        with open(os.path.join(examples, f"example_{module_name}.{ext}"), "w") as f:
+        with open(os.path.join(examples, f"example_{module_name}.{ext}"), "w", encoding="utf-8") as f:
             f.write(f"# [TODO] Exercise the {display_name} blueprint.\n")
         return None
 

--- a/src/cartograph/languages/go.py
+++ b/src/cartograph/languages/go.py
@@ -169,7 +169,7 @@ class GoEngine(LanguageEngine):
         # the scaffold's own files would fail the gofmt gate on Windows,
         # where text-mode writes translate \n to \r\n.
         def _w(path, content):
-            with open(path, "w", newline="\n") as f:
+            with open(path, "w", newline="\n", encoding="utf-8") as f:
                 f.write(content)
         _w(os.path.join(target_dir, "go.mod"),
            _GO_MOD.format(module=module_name, go_directive=_GO_DIRECTIVE))
@@ -390,7 +390,7 @@ class GoEngine(LanguageEngine):
         work_path = os.path.join(sandbox, "go.work")
         had_work = os.path.isfile(work_path)
         if not had_work:
-            with open(work_path, "w") as f:
+            with open(work_path, "w", encoding="utf-8") as f:
                 f.write(f"go {_GO_DIRECTIVE}\n\nuse (\n")
                 for d in work_dirs:
                     f.write(f"\t{d}\n")

--- a/src/cartograph/languages/javascript.py
+++ b/src/cartograph/languages/javascript.py
@@ -189,20 +189,20 @@ class JavaScriptEngine(LanguageEngine):
             "dependencies": {},
             "devDependencies": dev_deps,
         }
-        with open(os.path.join(target_dir, "package.json"), "w") as f:
+        with open(os.path.join(target_dir, "package.json"), "w", encoding="utf-8") as f:
             json.dump(pkg, f, indent=2)
 
-        with open(os.path.join(target_dir, "src", f"{module_name}.js"), "w") as f:
+        with open(os.path.join(target_dir, "src", f"{module_name}.js"), "w", encoding="utf-8") as f:
             f.write(_JS_PLAIN_SRC.format(name=display_name, module=module_name))
-        with open(os.path.join(target_dir, "tests", f"test_{module_name}.js"), "w") as f:
+        with open(os.path.join(target_dir, "tests", f"test_{module_name}.js"), "w", encoding="utf-8") as f:
             f.write(_JS_PLAIN_TEST.format(module=module_name))
-        with open(os.path.join(target_dir, "examples", "example_usage.js"), "w") as f:
+        with open(os.path.join(target_dir, "examples", "example_usage.js"), "w", encoding="utf-8") as f:
             f.write(_JS_PLAIN_EXAMPLE.format(name=display_name, module=module_name))
 
         # Always ship a vitest config so the widget runs standalone under
         # `vitest run` with no Cartograph injection. Frontend gets happy-dom.
         config = _VITEST_FRONTEND if is_frontend else _VITEST_FALLBACK
-        with open(os.path.join(target_dir, "vitest.config.js"), "w") as f:
+        with open(os.path.join(target_dir, "vitest.config.js"), "w", encoding="utf-8") as f:
             f.write(config)
 
     # ------------------------------------------------------------------ helpers
@@ -313,10 +313,10 @@ class JavaScriptEngine(LanguageEngine):
                 ver_part = dep[len(bare):].strip() or "*"
                 if bare:
                     pkg["dependencies"][bare] = ver_part
-            with open(package_json_path, "w") as f:
+            with open(package_json_path, "w", encoding="utf-8") as f:
                 json.dump(pkg, f, indent=2)
         else:
-            with open(package_json_path) as f:
+            with open(package_json_path, encoding="utf-8") as f:
                 pkg = json.load(f)
             dev = pkg.setdefault("devDependencies", {})
             changed = False
@@ -324,7 +324,7 @@ class JavaScriptEngine(LanguageEngine):
                 dev["vitest"] = "^1.0.0"
                 changed = True
             if changed:
-                with open(package_json_path, "w") as f:
+                with open(package_json_path, "w", encoding="utf-8") as f:
                     json.dump(pkg, f, indent=2)
 
         # Shared npm cache under cartograph's data dir. Stays warm across
@@ -433,11 +433,11 @@ class TypeScriptEngine(JavaScriptEngine):
         os.remove(os.path.join(target_dir, "src", f"{module_name}.js"))
         os.remove(os.path.join(target_dir, "tests", f"test_{module_name}.js"))
         os.remove(os.path.join(target_dir, "examples", "example_usage.js"))
-        with open(os.path.join(target_dir, "src", f"{module_name}.ts"), "w") as f:
+        with open(os.path.join(target_dir, "src", f"{module_name}.ts"), "w", encoding="utf-8") as f:
             f.write(_TS_SRC.format(name=display_name, module=module_name))
-        with open(os.path.join(target_dir, "tests", f"test_{module_name}.ts"), "w") as f:
+        with open(os.path.join(target_dir, "tests", f"test_{module_name}.ts"), "w", encoding="utf-8") as f:
             f.write(_TS_TEST.format(module=module_name))
-        with open(os.path.join(target_dir, "examples", "example_usage.ts"), "w") as f:
+        with open(os.path.join(target_dir, "examples", "example_usage.ts"), "w", encoding="utf-8") as f:
             f.write(_TS_EXAMPLE.format(name=display_name, module=module_name))
 
     def example_filename(self, path: str = "") -> str:

--- a/src/cartograph/languages/nim.py
+++ b/src/cartograph/languages/nim.py
@@ -120,13 +120,13 @@ class NimEngine(LanguageEngine):
         # to guarantee no collision with any stdlib module.
         src_module = f"{module_name}_lib"
 
-        with open(os.path.join(target_dir, f"{module_name}.nimble"), "w") as f:
+        with open(os.path.join(target_dir, f"{module_name}.nimble"), "w", encoding="utf-8") as f:
             f.write(_NIMBLE_TEMPLATE.format(name=display_name))
-        with open(os.path.join(target_dir, "src", f"{src_module}.nim"), "w") as f:
+        with open(os.path.join(target_dir, "src", f"{src_module}.nim"), "w", encoding="utf-8") as f:
             f.write(_SRC_TEMPLATE.format(name=display_name, module=module_name))
-        with open(os.path.join(target_dir, "tests", f"test_{module_name}.nim"), "w") as f:
+        with open(os.path.join(target_dir, "tests", f"test_{module_name}.nim"), "w", encoding="utf-8") as f:
             f.write(_TEST_TEMPLATE.format(name=display_name, src_module=src_module))
-        with open(os.path.join(target_dir, "examples", "example_usage.nim"), "w") as f:
+        with open(os.path.join(target_dir, "examples", "example_usage.nim"), "w", encoding="utf-8") as f:
             f.write(_EXAMPLE_TEMPLATE.format(name=display_name, module=module_name, src_module=src_module))
 
     # -- Custom validation (nim check + compile check on top of base scanner) --
@@ -366,7 +366,7 @@ class NimEngine(LanguageEngine):
         if not os.path.exists(nimble_path):
             return
         try:
-            with open(nimble_path) as f:
+            with open(nimble_path, encoding="utf-8") as f:
                 content = f.read()
 
             wanted: dict[str, str] = {}
@@ -399,7 +399,7 @@ class NimEngine(LanguageEngine):
 
             new_content = "".join(new_lines)
             if new_content != content:
-                with open(nimble_path, "w") as f:
+                with open(nimble_path, "w", encoding="utf-8") as f:
                     f.write(new_content)
                 log.debug("Synced %d dep(s) to %s", len(additions),
                           os.path.basename(nimble_path))

--- a/src/cartograph/languages/openscad.py
+++ b/src/cartograph/languages/openscad.py
@@ -555,19 +555,19 @@ class OpenSCADEngine(LanguageEngine):
                     os.unlink(p)
 
     def scaffold(self, target_dir, module_name, display_name, **kwargs):
-        with open(os.path.join(target_dir, "src", f"{module_name}.scad"), "w") as f:
+        with open(os.path.join(target_dir, "src", f"{module_name}.scad"), "w", encoding="utf-8") as f:
             f.write(_SCAD_SRC.format(module=module_name, name=display_name))
-        with open(os.path.join(target_dir, "tests", f"test_{module_name}.scad"), "w") as f:
+        with open(os.path.join(target_dir, "tests", f"test_{module_name}.scad"), "w", encoding="utf-8") as f:
             f.write(_SCAD_TEST.format(module=module_name, name=display_name))
-        with open(os.path.join(target_dir, "examples", "example_usage.scad"), "w") as f:
+        with open(os.path.join(target_dir, "examples", "example_usage.scad"), "w", encoding="utf-8") as f:
             f.write(_SCAD_EXAMPLE.format(module=module_name, name=display_name))
         # Optional Python sidecar - calc helpers that mirror the .scad module.
         # Always scaffolded so users can opt in by editing; delete the dir to opt out.
         py_dir = os.path.join(target_dir, "python")
         os.makedirs(py_dir, exist_ok=True)
-        with open(os.path.join(py_dir, f"{module_name}.py"), "w") as f:
+        with open(os.path.join(py_dir, f"{module_name}.py"), "w", encoding="utf-8") as f:
             f.write(_PY_SIDECAR_SRC.format(module=module_name, name=display_name))
-        with open(os.path.join(py_dir, f"test_{module_name}.py"), "w") as f:
+        with open(os.path.join(py_dir, f"test_{module_name}.py"), "w", encoding="utf-8") as f:
             f.write(_PY_SIDECAR_TEST.format(module=module_name, name=display_name))
 
     def example_filename(self, path: str = "") -> str:

--- a/src/cartograph/languages/php.py
+++ b/src/cartograph/languages/php.py
@@ -216,19 +216,19 @@ class PhpEngine(LanguageEngine):
                     .replace("__DISPLAY__", display_name)
                     .replace("__SLUG__", slug))
 
-        with open(os.path.join(target_dir, "src", f"{class_name}.php"), "w") as f:
+        with open(os.path.join(target_dir, "src", f"{class_name}.php"), "w", encoding="utf-8") as f:
             f.write(sub(_SRC_TEMPLATE))
 
-        with open(os.path.join(target_dir, "tests", f"{class_name}Test.php"), "w") as f:
+        with open(os.path.join(target_dir, "tests", f"{class_name}Test.php"), "w", encoding="utf-8") as f:
             f.write(sub(_TEST_TEMPLATE))
 
-        with open(os.path.join(target_dir, "examples", "example_usage.php"), "w") as f:
+        with open(os.path.join(target_dir, "examples", "example_usage.php"), "w", encoding="utf-8") as f:
             f.write(sub(_EXAMPLE_TEMPLATE))
 
-        with open(os.path.join(target_dir, "composer.json"), "w") as f:
+        with open(os.path.join(target_dir, "composer.json"), "w", encoding="utf-8") as f:
             f.write(sub(_COMPOSER_JSON))
 
-        with open(os.path.join(target_dir, "phpunit.xml"), "w") as f:
+        with open(os.path.join(target_dir, "phpunit.xml"), "w", encoding="utf-8") as f:
             f.write(_PHPUNIT_XML)
 
     # ── Contamination ─────────────────────────────────────────────────────────
@@ -274,7 +274,7 @@ class PhpEngine(LanguageEngine):
             if not os.path.exists(p):
                 continue
             try:
-                content = open(p).read()
+                content = open(p, encoding="utf-8").read()
             except Exception:
                 continue
             for m in psr_re.finditer(content):
@@ -286,7 +286,7 @@ class PhpEngine(LanguageEngine):
         cm = os.path.join(autoload_dir, "autoload_classmap.php")
         if os.path.exists(cm):
             try:
-                content = open(cm).read()
+                content = open(cm, encoding="utf-8").read()
                 fq_re = re.compile(r"'([A-Za-z_][A-Za-z0-9_]*(?:\\\\[A-Za-z_][A-Za-z0-9_]*)+)'\s*=>")
                 for m in fq_re.finditer(content):
                     key = m.group(1).replace("\\\\", "\\")
@@ -351,7 +351,7 @@ class PhpEngine(LanguageEngine):
         for fpath, is_src, is_example in all_files:
             rel = os.path.relpath(fpath, path)
             try:
-                code = open(fpath).read()
+                code = open(fpath, encoding="utf-8").read()
             except Exception as e:
                 blocks.append(f"Could not read {rel}: {e}")
                 continue
@@ -465,7 +465,7 @@ class PhpEngine(LanguageEngine):
     def install_deps(self, path: str, dependencies: list) -> None:
         composer_path = os.path.join(path, "composer.json")
         if os.path.exists(composer_path) and dependencies:
-            with open(composer_path) as f:
+            with open(composer_path, encoding="utf-8") as f:
                 pkg = json.load(f)
             changed = False
             for dep in dependencies:
@@ -479,7 +479,7 @@ class PhpEngine(LanguageEngine):
                     pkg.setdefault("require", {})[bare] = ver_part
                     changed = True
             if changed:
-                with open(composer_path, "w") as f:
+                with open(composer_path, "w", encoding="utf-8") as f:
                     json.dump(pkg, f, indent=4)
                     f.write("\n")
 

--- a/src/cartograph/languages/python.py
+++ b/src/cartograph/languages/python.py
@@ -110,7 +110,7 @@ class PythonEngine(LanguageEngine):
     def _find_print_calls(self, fpath: str) -> list:
         """Return line numbers of print() calls in actual code, skipping docstrings."""
         try:
-            with open(fpath) as f:
+            with open(fpath, encoding="utf-8") as f:
                 source = f.read()
             tree = ast.parse(source)
         except Exception:
@@ -177,7 +177,7 @@ class PythonEngine(LanguageEngine):
             is_src = fpath in src_files
             is_example = fpath in example_files
             try:
-                code = open(fpath).read()
+                code = open(fpath, encoding="utf-8").read()
             except Exception as e:
                 blocks.append(f"Could not read source file {rel}: {e}")
                 continue
@@ -329,13 +329,13 @@ class PythonEngine(LanguageEngine):
         return results
 
     def scaffold(self, target_dir, module_name, display_name, **_):
-        with open(os.path.join(target_dir, "src", "__init__.py"), "w") as f:
+        with open(os.path.join(target_dir, "src", "__init__.py"), "w", encoding="utf-8") as f:
             f.write(_SRC_INIT)
-        with open(os.path.join(target_dir, "src", f"{module_name}.py"), "w") as f:
+        with open(os.path.join(target_dir, "src", f"{module_name}.py"), "w", encoding="utf-8") as f:
             f.write(_SRC_TEMPLATE.format(module=module_name, name=display_name))
-        with open(os.path.join(target_dir, "tests", f"test_{module_name}.py"), "w") as f:
+        with open(os.path.join(target_dir, "tests", f"test_{module_name}.py"), "w", encoding="utf-8") as f:
             f.write(_TEST_TEMPLATE)
-        with open(os.path.join(target_dir, "examples", "example_usage.py"), "w") as f:
+        with open(os.path.join(target_dir, "examples", "example_usage.py"), "w", encoding="utf-8") as f:
             f.write(_EXAMPLE_TEMPLATE.format(module=module_name, name=display_name))
 
     def src_import_pattern(self) -> str | None:
@@ -551,7 +551,7 @@ class PythonEngine(LanguageEngine):
             rel = os.path.relpath(fpath, widget_path)
             is_src = fpath in src_files
             try:
-                code = open(fpath).read()
+                code = open(fpath, encoding="utf-8").read()
             except Exception as e:
                 blocks.append(f"Could not read {rel}: {e}")
                 continue

--- a/src/cartograph/languages/spice.py
+++ b/src/cartograph/languages/spice.py
@@ -306,19 +306,42 @@ class SpiceEngine(LanguageEngine):
     # ---- simulation runner -------------------------------------------------
 
     def _simulate(self, netlist: str, cwd: str, timeout: int = 60):
-        """Run `ngspice -b <netlist>` and return (ok, combined_output).
+        """Run `ngspice -b -o <log> <netlist>` and return (ok, combined_output).
 
         ok is False when the output carries any hard-error marker. The exit
         code is deliberately ignored - ngspice returns 0 even on failure.
+
+        The `-o <log>` flag mirrors ngspice's batch output to a file. On
+        Windows the `.control` block's `echo` lines (our ASSERT_PASS/FAIL
+        sentinels) do not reliably reach the captured stdout/stderr pipes,
+        but they always land in the `-o` log. We union the log with the
+        captured streams so assertion detection is platform-independent.
         """
         binary = self._binary()
         if not binary:
             return False, "ngspice not found - install ngspice 40+"
+        fd, logpath = tempfile.mkstemp(prefix="cg_ngspice_", suffix=".log")
+        os.close(fd)
         try:
-            res = self._run([binary, "-b", netlist], cwd=cwd, timeout=timeout)
+            res = self._run([binary, "-b", "-o", logpath, netlist],
+                            cwd=cwd, timeout=timeout)
         except FileNotFoundError:
+            os.unlink(logpath)
             return False, "ngspice not found - install ngspice 40+"
-        combined = (res.stdout or "") + "\n" + (res.stderr or "")
+        log_text = ""
+        try:
+            with open(logpath, encoding="utf-8", errors="replace") as f:
+                log_text = f.read()
+        except OSError:
+            pass
+        finally:
+            try:
+                os.unlink(logpath)
+            except OSError:
+                pass
+        combined = "\n".join(
+            part for part in (res.stdout, res.stderr, log_text) if part
+        )
         if _ERROR_MARKERS.search(combined):
             return False, combined.strip()
         return True, combined.strip()

--- a/src/cartograph/languages/spice.py
+++ b/src/cartograph/languages/spice.py
@@ -271,13 +271,13 @@ class SpiceEngine(LanguageEngine):
         for d in ("src", "tests", "examples"):
             os.makedirs(os.path.join(target_dir, d), exist_ok=True)
         with open(os.path.join(target_dir, "src", f"{module_name}.cir"),
-                  "w") as f:
+                  "w", encoding="utf-8") as f:
             f.write(_SPICE_SRC.format(module=module_name, name=display_name))
         with open(os.path.join(target_dir, "tests",
-                               f"test_{module_name}.cir"), "w") as f:
+                               f"test_{module_name}.cir"), "w", encoding="utf-8") as f:
             f.write(_SPICE_TEST.format(module=module_name, name=display_name))
         with open(os.path.join(target_dir, "examples", "example_usage.cir"),
-                  "w") as f:
+                  "w", encoding="utf-8") as f:
             f.write(_SPICE_EXAMPLE.format(module=module_name,
                                           name=display_name))
 

--- a/src/cartograph/languages/systemverilog.py
+++ b/src/cartograph/languages/systemverilog.py
@@ -589,7 +589,7 @@ class SystemVerilogEngine(LanguageEngine):
             os.makedirs(d, exist_ok=True)
 
         def _write(path, content):
-            with open(path, "w") as f:
+            with open(path, "w", encoding="utf-8") as f:
                 f.write(content)
 
         _write(

--- a/src/cartograph/languages/terraform.py
+++ b/src/cartograph/languages/terraform.py
@@ -282,17 +282,17 @@ class TerraformEngine(LanguageEngine):
         os.makedirs(tests_dir, exist_ok=True)
         os.makedirs(ex_dir, exist_ok=True)
 
-        with open(os.path.join(src_dir, f"{module_name}.tf"), "w") as f:
+        with open(os.path.join(src_dir, f"{module_name}.tf"), "w", encoding="utf-8") as f:
             f.write(_TF_MAIN.format(module=module_name, name=display_name))
-        with open(os.path.join(src_dir, "variables.tf"), "w") as f:
+        with open(os.path.join(src_dir, "variables.tf"), "w", encoding="utf-8") as f:
             f.write(_TF_VARIABLES.format(module=module_name))
-        with open(os.path.join(src_dir, "outputs.tf"), "w") as f:
+        with open(os.path.join(src_dir, "outputs.tf"), "w", encoding="utf-8") as f:
             f.write(_TF_OUTPUTS.format(module=module_name))
-        with open(os.path.join(src_dir, "versions.tf"), "w") as f:
+        with open(os.path.join(src_dir, "versions.tf"), "w", encoding="utf-8") as f:
             f.write(_TF_VERSIONS)
-        with open(os.path.join(tests_dir, f"test_{module_name}.tf"), "w") as f:
+        with open(os.path.join(tests_dir, f"test_{module_name}.tf"), "w", encoding="utf-8") as f:
             f.write(_TF_TEST.format(module=module_name))
-        with open(os.path.join(ex_dir, "example_usage.tf"), "w") as f:
+        with open(os.path.join(ex_dir, "example_usage.tf"), "w", encoding="utf-8") as f:
             f.write(_TF_EXAMPLE.format(module=module_name, name=display_name))
 
     def find_test_files(self, path: str) -> list[str]:

--- a/src/cartograph/manifest.py
+++ b/src/cartograph/manifest.py
@@ -104,7 +104,7 @@ def load_manifest(path: str) -> Manifest:
 
     manifest_path = os.path.join(path, manifest_filename(kind))
     try:
-        with open(manifest_path) as f:
+        with open(manifest_path, encoding="utf-8") as f:
             raw = json.load(f)
     except (OSError, json.JSONDecodeError) as e:
         raise ManifestError(f"Could not read {manifest_path}: {e}") from e

--- a/src/cartograph/scaffolding/__init__.py
+++ b/src/cartograph/scaffolding/__init__.py
@@ -21,7 +21,7 @@ _CONFIG_PATH = os.path.join(os.path.dirname(__file__), "..", "library_config.jso
 def _library_notes(language: str, domain: str = "") -> dict:
     """Load general + language-specific + domain-specific notes from library_config.json."""
     try:
-        with open(_CONFIG_PATH) as f:
+        with open(_CONFIG_PATH, encoding="utf-8") as f:
             cfg = json.load(f)
     except Exception:
         return {}
@@ -108,7 +108,7 @@ def create_widget(carto, item_id, language, name=None, domain=None, tags=None,
         "custom_notes": "",
         "library_notes": _library_notes(normalized_lang, domain),
     }
-    with open(os.path.join(target_dir, "widget.json"), "w") as f:
+    with open(os.path.join(target_dir, "widget.json"), "w", encoding="utf-8") as f:
         json.dump(manifest, f, indent=2)
 
     # Write language-specific files from engine scaffold
@@ -194,7 +194,7 @@ def create_blueprint(carto, name, language, target_dir=None, description=None, t
         "dependencies": [],
         "domains": [],
     }
-    with open(os.path.join(target_dir, "blueprint.json"), "w") as f:
+    with open(os.path.join(target_dir, "blueprint.json"), "w", encoding="utf-8") as f:
         json.dump(manifest, f, indent=2)
 
     # Derive a module name from the slug for placeholder files.

--- a/src/cartograph/search/filters.py
+++ b/src/cartograph/search/filters.py
@@ -8,8 +8,16 @@ from ..engine import normalize_language
 
 
 def apply_filters(widget: dict, domain_filter: str | None,
-                  language_filter: str | None) -> bool:
-    """Return True if the widget passes all active filters."""
+                  language_filter: str | None,
+                  languages: set[str] | None = None) -> bool:
+    """Return True if the widget passes all active filters.
+
+    `language_filter` is the single-language `--language` narrowing.
+    `languages`, if given, is a set of canonical languages the widget's
+    language must intersect (machine-availability scoping for the
+    show-unavailable config). Both may be active at once; the widget must
+    satisfy each.
+    """
     if domain_filter and domain_filter != "all":
         # Blueprints carry a multi-valued `domains` list (union of dep
         # widget domains). Widgets carry single-valued `domain`. Either
@@ -22,16 +30,21 @@ def apply_filters(widget: dict, domain_filter: str | None,
         if domain_filter not in domains and single != domain_filter:
             return False
 
-    if language_filter:
-        filter_val = normalize_language(language_filter)
+    if language_filter or languages:
         w_lang = widget.get("language", "")
         if isinstance(w_lang, list):
             w_langs = {normalize_language(l) for l in w_lang}
         else:
             w_langs = {normalize_language(l)
                        for l in str(w_lang).replace(",", " ").replace("/", " ").split()}
-        if filter_val not in w_langs:
+        if language_filter and normalize_language(language_filter) not in w_langs:
             return False
+        if languages:
+            # Normalize set members so callers can pass raw aliases (e.g. the
+            # server receives "py"/"ts" straight off the query string).
+            allowed = {normalize_language(l) for l in languages}
+            if w_langs.isdisjoint(allowed):
+                return False
 
     return True
 

--- a/src/cartograph/search/hybrid.py
+++ b/src/cartograph/search/hybrid.py
@@ -64,7 +64,8 @@ class HybridBackend:
         self._ngram.build(widgets)
 
     def query(self, query: str, domain_filter: str | None = None,
-              language_filter: str | None = None, top_k: int = 10) -> dict:
+              language_filter: str | None = None, top_k: int = 10,
+              languages: set[str] | None = None) -> dict:
         if not self._widgets:
             return {"results": []}
 
@@ -98,7 +99,7 @@ class HybridBackend:
             if combined < _MIN_SCORE:
                 continue
 
-            if not apply_filters(widget, None, language_filter):
+            if not apply_filters(widget, None, language_filter, languages):
                 continue
 
             scored_all.append({**widget, "relevance_score": round(combined, 4)})

--- a/src/cartograph/search/tfidf.py
+++ b/src/cartograph/search/tfidf.py
@@ -23,7 +23,7 @@ import re
 _SYNONYMS_PATH = os.path.join(os.path.dirname(__file__), "synonyms.json")
 
 try:
-    with open(_SYNONYMS_PATH) as f:
+    with open(_SYNONYMS_PATH, encoding="utf-8") as f:
         _SYNONYMS: dict[str, list[str]] = json.load(f)
 except Exception:
     _SYNONYMS = {}

--- a/src/cartograph/update_check.py
+++ b/src/cartograph/update_check.py
@@ -56,7 +56,7 @@ def _is_newer(latest: str, current: str) -> bool:
 def _read_cache(now: float | None = None) -> dict:
     now = time.time() if now is None else now
     try:
-        with open(_cache_path()) as f:
+        with open(_cache_path(), encoding="utf-8") as f:
             data = json.load(f)
         if now - float(data.get("checked_at", 0)) < _CACHE_SECONDS:
             return data
@@ -68,7 +68,7 @@ def _read_cache(now: float | None = None) -> dict:
 def _write_cache(data: dict) -> None:
     path = _cache_path()
     os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2, sort_keys=True)
 
 

--- a/src/cartograph/validator.py
+++ b/src/cartograph/validator.py
@@ -20,7 +20,7 @@ def _load_domains() -> frozenset:
     """Load valid domains from library_config.json - single source of truth."""
     config_path = os.path.join(os.path.dirname(__file__), "library_config.json")
     try:
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             return frozenset(json.load(f)["domains"].keys())
     except Exception:
         # Fallback if config is missing/broken - should never happen in production
@@ -56,7 +56,7 @@ def validate_item(carto, path):
 
     # 3. Valid JSON, no TODOs
     try:
-        content = open(manifest_path).read()
+        content = open(manifest_path, encoding="utf-8").read()
         data = json.loads(content)
         check("widget.json is valid JSON", True)
     except (OSError, json.JSONDecodeError) as e:
@@ -154,7 +154,7 @@ def validate_item(carto, path):
         current_notes = data.get("library_notes")
         if current_notes != canonical_notes:
             data["library_notes"] = canonical_notes
-            with open(manifest_path, "w") as f:
+            with open(manifest_path, "w", encoding="utf-8") as f:
                 json.dump(data, f, indent=2)
             contam_warnings.append(
                 "library_notes drifted from canonical and was restored. "
@@ -188,7 +188,7 @@ def validate_item(carto, path):
             _print_checklist(checklist, errors, failed=True)
             return {"status": "error", "message": f"Missing examples/{example_file}"}
 
-        example_content = open(example_path).read()
+        example_content = open(example_path, encoding="utf-8").read()
         example_todos = example_content.count("[TODO]")
         if not check(f"No [TODO] in {example_file}", example_todos == 0,
                      f"Found {example_todos} [TODO] placeholder(s) in examples/{example_file} — write real example code"):

--- a/tests/test_blueprint_languages.py
+++ b/tests/test_blueprint_languages.py
@@ -16,6 +16,7 @@ import json
 import os
 import shutil
 import sys
+import tempfile
 
 import pytest
 
@@ -1359,6 +1360,45 @@ def _write_spice_blueprint(project_dir: str) -> str:
     with open(os.path.join(bp, "examples", "example_usage.cir"), "w") as f:
         f.write(_SPICE_CASCADE_EXAMPLE)
     return bp
+
+
+@pytest.mark.slow
+def test_spice_simulate_captures_control_echo():
+    """Windows probe: ngspice's `.control` echo must reach captured output.
+
+    This is the exact failure mode that kept SPICE dormant on Windows - an
+    `echo` inside `.control` (how testbenches emit ASSERT_PASS/FAIL) did not
+    surface in the captured stdout/stderr pipes there, so the engine never saw
+    a sentinel. `_simulate` now also reads ngspice's `-o` log and unions it in,
+    which should make sentinel capture platform-independent. Deliberately NOT
+    skipped on win32 - this is the guard that tells us Windows is fixed before
+    we flip the engine to supported=True.
+    """
+    if not shutil.which("ngspice"):
+        pytest.skip("ngspice not available")
+    engine = get_engine("spice")
+    if engine is None:
+        pytest.skip("spice engine not available")
+    netlist = (
+        "* echo capture probe\n"
+        "V1 in 0 DC 1\n"
+        "R1 in 0 1k\n"
+        ".control\n"
+        "op\n"
+        'echo "ASSERT_PASS probe echo captured"\n'
+        ".endc\n"
+        ".end\n"
+    )
+    with tempfile.TemporaryDirectory() as d:
+        nl = os.path.join(d, "probe.cir")
+        with open(nl, "w", encoding="utf-8") as f:
+            f.write(netlist)
+        ok, output = engine._simulate(nl, cwd=d)
+    assert ok, output
+    assert "ASSERT_PASS" in output, (
+        "ngspice .control echo was not captured - the -o log union should make "
+        "this platform-independent. Output:\n" + output
+    )
 
 
 @pytest.mark.slow

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -133,3 +133,83 @@ def test_search_row_does_not_mutate_input():
     _search_row(original)
     assert original["trend"] == "up"
     assert len(original["description"]) == 999
+
+
+# ---------------------------------------------------------------------------
+# show-unavailable: language-set scoping (cloud search parity with local).
+#
+# Local search filters unavailable languages out of the corpus at library-load
+# time, so the index never contains them. Cloud rows bypass that path, so the
+# CLI sends the client's available-language SET to the registry and the shared
+# backend filters on it BEFORE ranking/truncation. These tests pin that the
+# filter is pre-rank (fills top_k with installable widgets) and alias-tolerant.
+# ---------------------------------------------------------------------------
+
+def _retry_corpus(langs):
+    """One identically-relevant 'retry' widget per language."""
+    return [
+        {"id": f"universal-retry-{l}", "name": "retry", "domain": "universal",
+         "description": "retry backoff", "language": l, "weighted_rating": 0}
+        for l in langs
+    ]
+
+
+def test_languages_filter_scopes_results():
+    from cartograph.search import HybridBackend
+    b = HybridBackend()
+    b.build(_retry_corpus(["python", "go", "nim", "php", "typescript"]))
+    res = b.query("retry", top_k=10, languages={"python", "go"})
+    langs = {w["language"] for w in res["results"]}
+    assert langs == {"python", "go"}
+
+
+def test_languages_filter_is_pre_rank_fills_top_k():
+    """The discriminator: with the cut smaller than the corpus and unavailable
+    widgets interleaved through the ranking, a post-rank-after-truncation filter
+    would under-fill. Pre-rank must return a full top_k of available widgets."""
+    from cartograph.search import HybridBackend
+    widgets = []
+    for i in range(8):  # interleaved go, python, go, python, ...
+        widgets.append({"id": f"universal-retry-go-{i}", "name": "retry",
+                        "domain": "universal", "description": "retry",
+                        "language": "go", "weighted_rating": 0})
+        widgets.append({"id": f"universal-retry-py-{i}", "name": "retry",
+                        "domain": "universal", "description": "retry",
+                        "language": "python", "weighted_rating": 0})
+    b = HybridBackend()
+    b.build(widgets)
+    res = b.query("retry", top_k=5, languages={"python"})
+    assert [w["language"] for w in res["results"]] == ["python"] * 5
+
+
+def test_languages_filter_normalizes_aliases():
+    from cartograph.search import HybridBackend
+    b = HybridBackend()
+    b.build(_retry_corpus(["python", "typescript", "go"]))
+    res = b.query("retry", top_k=10, languages={"py", "ts"})  # raw aliases
+    assert {w["language"] for w in res["results"]} == {"python", "typescript"}
+
+
+def test_languages_none_is_noop():
+    from cartograph.search import HybridBackend
+    corpus = _retry_corpus(["python", "go", "nim"])
+    b = HybridBackend()
+    b.build(corpus)
+    assert len(b.query("retry", top_k=10)["results"]) == len(corpus)
+
+
+def test_languages_filter_combines_with_single_language():
+    from cartograph.search import HybridBackend
+    b = HybridBackend()
+    b.build(_retry_corpus(["python", "go"]))
+    res = b.query("retry", top_k=10, language_filter="go", languages={"python", "go"})
+    assert [w["language"] for w in res["results"]] == ["go"]
+
+
+def test_apply_filters_languages_set():
+    from cartograph.search.filters import apply_filters
+    w = {"language": "python", "domain": "universal"}
+    assert apply_filters(w, None, None, {"python", "go"}) is True
+    assert apply_filters(w, None, None, {"go", "nim"}) is False
+    # alias members are normalized
+    assert apply_filters(w, None, None, {"py"}) is True


### PR DESCRIPTION
Cuts **v0.7.10**. Merging to master triggers the auto-tag + PyPI publish pipeline.

### show-unavailable cloud scoping (new)
`show-unavailable false` was only enforced on local results; cloud/registry rows ignored it. Now:
- CLI sends the machine's available-language set (`&languages=...`) to registries.
- Shared `HybridBackend` applies it as a **pre-rank** hard filter so `top_k` fills with installable widgets (proven by `test_languages_filter_is_pre_rank_fills_top_k`).
- Client-side backstop re-filters merged rows so the config holds regardless of registry support.
- `REGISTRY.md` documents the `languages` param contract.
- Companion `cartograph-cloud` handler activates once its pin bumps to 0.7.10.

### Windows encoding sweep
All text-mode `open()` pinned to `encoding="utf-8"` (cp1252 default bug).

### SPICE .control echo capture
ngspice `-o` log capture for the Windows echo path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)