### PR TITLE
ci: run the full test matrix once per release, not three times

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,8 +11,14 @@ on:
 
 jobs:
   # Full 9-cell matrix on the tagged commit. Blocks PyPI upload.
+  #
+  # Skipped on the auto-tag path (workflow_dispatch): test.yml already ran the
+  # full matrix on this exact commit on the master push that created the tag,
+  # so re-running it here is pure duplication. Kept for raw `push` of a tag
+  # (a hand-cut release) where no prior gating run is guaranteed.
   tests:
     name: Tests
+    if: github.event_name != 'workflow_dispatch'
     uses: ./.github/workflows/test.yml
     with:
       full_install: true
@@ -20,6 +26,9 @@ jobs:
   publish:
     name: Build and publish
     needs: tests
+    # Proceed when tests passed OR were skipped (auto-tag path, already gated
+    # on master). Without always() a skipped `needs` would skip publish too.
+    if: ${{ always() && needs.tests.result != 'failure' && needs.tests.result != 'cancelled' }}
     runs-on: ubuntu-latest
     environment: pypi
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,12 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
 
+    # Install every engine when this is a release-gating run: any push to
+    # master (the auto-tag/publish chain reads this same run) or an explicit
+    # full_install caller. PRs stay path-filtered for fast feedback.
+    env:
+      FULL_INSTALL: ${{ inputs.full_install || github.event_name == 'push' }}
+
     steps:
       - uses: actions/checkout@v6
 
@@ -67,23 +73,23 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install iverilog (Linux)
-        if: matrix.os == 'ubuntu-latest' && (inputs.full_install || steps.changes.outputs.core == 'true' || steps.changes.outputs.systemverilog == 'true')
+        if: matrix.os == 'ubuntu-latest' && (env.FULL_INSTALL == 'true' || steps.changes.outputs.core == 'true' || steps.changes.outputs.systemverilog == 'true')
         run: sudo apt-get update && sudo apt-get install -y iverilog
 
       - name: Install iverilog (macOS)
-        if: matrix.os == 'macos-latest' && (inputs.full_install || steps.changes.outputs.core == 'true' || steps.changes.outputs.systemverilog == 'true')
+        if: matrix.os == 'macos-latest' && (env.FULL_INSTALL == 'true' || steps.changes.outputs.core == 'true' || steps.changes.outputs.systemverilog == 'true')
         run: brew install icarus-verilog
 
       - name: Install iverilog (Windows)
-        if: matrix.os == 'windows-latest' && (inputs.full_install || steps.changes.outputs.core == 'true' || steps.changes.outputs.systemverilog == 'true')
+        if: matrix.os == 'windows-latest' && (env.FULL_INSTALL == 'true' || steps.changes.outputs.core == 'true' || steps.changes.outputs.systemverilog == 'true')
         run: choco install iverilog -y || (sleep 15 && choco install iverilog -y)
 
       - name: Install Angular CLI
-        if: inputs.full_install || steps.changes.outputs.core == 'true' || steps.changes.outputs.angular == 'true'
+        if: env.FULL_INSTALL == 'true' || steps.changes.outputs.core == 'true' || steps.changes.outputs.angular == 'true'
         run: npm install -g @angular/cli
 
       - name: Install PHP and Composer
-        if: inputs.full_install || steps.changes.outputs.core == 'true' || steps.changes.outputs.php == 'true'
+        if: env.FULL_INSTALL == 'true' || steps.changes.outputs.core == 'true' || steps.changes.outputs.php == 'true'
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.2'
@@ -91,7 +97,7 @@ jobs:
           tools: composer
 
       - name: Install Terraform
-        if: inputs.full_install || steps.changes.outputs.core == 'true' || steps.changes.outputs.terraform == 'true'
+        if: env.FULL_INSTALL == 'true' || steps.changes.outputs.core == 'true' || steps.changes.outputs.terraform == 'true'
         uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: '1.9.0'
@@ -99,21 +105,21 @@ jobs:
 
       # setup-go works identically on all three platforms - no per-OS steps.
       - name: Install Go
-        if: inputs.full_install || steps.changes.outputs.core == 'true' || steps.changes.outputs.go == 'true'
+        if: env.FULL_INSTALL == 'true' || steps.changes.outputs.core == 'true' || steps.changes.outputs.go == 'true'
         uses: actions/setup-go@v6
         with:
           go-version: 'stable'
 
       - name: Install ngspice (Linux)
-        if: matrix.os == 'ubuntu-latest' && (inputs.full_install || steps.changes.outputs.core == 'true' || steps.changes.outputs.spice == 'true')
+        if: matrix.os == 'ubuntu-latest' && (env.FULL_INSTALL == 'true' || steps.changes.outputs.core == 'true' || steps.changes.outputs.spice == 'true')
         run: sudo apt-get update && sudo apt-get install -y ngspice
 
       - name: Install ngspice (macOS)
-        if: matrix.os == 'macos-latest' && (inputs.full_install || steps.changes.outputs.core == 'true' || steps.changes.outputs.spice == 'true')
+        if: matrix.os == 'macos-latest' && (env.FULL_INSTALL == 'true' || steps.changes.outputs.core == 'true' || steps.changes.outputs.spice == 'true')
         run: brew install ngspice
 
       - name: Install ngspice (Windows)
-        if: matrix.os == 'windows-latest' && (inputs.full_install || steps.changes.outputs.core == 'true' || steps.changes.outputs.spice == 'true')
+        if: matrix.os == 'windows-latest' && (env.FULL_INSTALL == 'true' || steps.changes.outputs.core == 'true' || steps.changes.outputs.spice == 'true')
         run: choco install ngspice -y || (sleep 15 && choco install ngspice -y)
 
       - name: Install dependencies


### PR DESCRIPTION
A single release ran the 9-cell matrix **three times**: on the PR, again on the master-merge push, and a third time inside `publish.yml` on the tag. The last two test the *same* tagged commit back to back.

### Change
- **test.yml**: master pushes now full-install every engine (`env.FULL_INSTALL`), so the master-push run is a complete release gate. PRs stay path-filtered for fast feedback.
- **publish.yml**: skip the `tests` job on the auto-tag path (`workflow_dispatch`) - that exact commit was just fully tested on the master push that cut the tag. `publish` proceeds when tests passed *or were skipped*. A raw `push` of a hand-cut tag still runs the matrix as a safety net.

### Net
Per release: PR matrix (pre-merge) + one full matrix on the release commit. `fresh-install` + post-publish smoke test unchanged.

### Tradeoff
Non-release master pushes now full-install (were path-filtered). Release commits already full-installed implicitly (version bump hits the `core` path filter), so releases don't get heavier - only the rare non-release merge does. Trades a little cost for a release gate that doesn't depend on the bump happening to touch a filtered path.

No version bump, so merging this does **not** trigger a release (auto-tag sees `v0.7.10` already exists and skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)