### PR TITLE
0.7.12: slug validation + checkin manual-bump pass-through + agent targets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cartograph-cli"
-version = "0.7.11"
+version = "0.7.12"
 description = "Widget library manager for AI agents — CLI"
 readme = "README.md"
 license = "MIT"

--- a/src/cartograph/checkin.py
+++ b/src/cartograph/checkin.py
@@ -36,6 +36,28 @@ from .validation_stamp import is_stamp_valid, write_stamp, STAMP_FILE as _STAMP_
 log = logging.getLogger("cartograph")
 
 
+def _bump_version(version: str, kind: str) -> str | None:
+    """Apply a semver bump (major/minor/patch) to ``version``.
+
+    Returns the bumped "X.Y.Z" string, or None if ``version`` is malformed.
+    Single source of truth for how checkin increments versions, so the
+    conflict check and the actual bump stay in lockstep.
+    """
+    try:
+        from packaging.version import Version as _Version
+        parsed = _Version(version)
+        major, minor, patch = parsed.major, parsed.minor, parsed.micro
+    except Exception:
+        return None
+    if kind == "major":
+        major, minor, patch = major + 1, 0, 0
+    elif kind == "minor":
+        minor, patch = minor + 1, 0
+    elif kind == "patch":
+        patch += 1
+    return f"{major}.{minor}.{patch}"
+
+
 def _artifact_skip_set(language: str | None) -> set[str]:
     """Return the build-artifact dirs to skip when copying widget files.
 
@@ -216,11 +238,53 @@ def checkin(carto, path: str, reason: str = "", version_bump: str = "minor",
     if baseline_version is not None:
         local_version = meta.get("version", "0.0.0")
         if local_version != baseline_version:
-            return {
-                "status": "error",
-                "message": f"Version conflict: local is v{local_version} but {baseline_source} is v{baseline_version}. "
-                           f"Install the latest version first, apply your changes, then checkin."
-            }
+            local_behind = _semver_key(local_version) < _semver_key(baseline_version)
+            if local_behind:
+                # The widget already exists at a newer version. Re-applying edits
+                # on a stale copy would clobber that newer work, so rebase first:
+                # upgrade pulls the latest baseline, then re-apply and checkin.
+                return {
+                    "status": "error",
+                    "message": f"{item_id}: local is v{local_version} but {baseline_source} "
+                               f"already has v{baseline_version}. Run "
+                               f"`cartograph upgrade {item_id}` to get the latest, "
+                               f"re-apply your changes, then checkin.",
+                }
+            # local ahead of baseline — the user hand-bumped meta.version
+            # instead of letting --bump do it. Accept it as a pre-applied bump
+            # IFF it exactly matches the bump they asked for, applied to the
+            # resolved baseline (cloud when the sidecar routes there, else
+            # library). Otherwise their manual version is inconsistent with the
+            # requested --bump and we error with the exact value to use.
+            expected = _bump_version(baseline_version, version_bump)
+            if expected is None:
+                return {"status": "error",
+                        "message": f"Cannot compare against malformed {baseline_source} "
+                                   f"version '{baseline_version}'."}
+            if local_version != expected:
+                # Figure out which --bump level the manual edit corresponds to,
+                # so we can hand the user the exact command to run.
+                intended = next(
+                    (k for k in ("patch", "minor", "major")
+                     if _bump_version(baseline_version, k) == local_version),
+                    None,
+                )
+                if intended:
+                    fix = (f"Your edit is a {intended} bump of v{baseline_version} - "
+                           f"re-run with `--bump {intended}`.")
+                else:
+                    fix = (f"v{local_version} isn't a clean patch/minor/major bump of "
+                           f"v{baseline_version} - reset meta.version to v{baseline_version} "
+                           f"and let `--bump` set it.")
+                return {
+                    "status": "error",
+                    "message": f"{item_id}: local is v{local_version} but a {version_bump} "
+                               f"bump of {baseline_source} v{baseline_version} is v{expected}. "
+                               + fix,
+                }
+            # Valid pre-applied bump: fall through. new_version is computed from
+            # the baseline below, so it lands on exactly v{expected} == local
+            # with no double-bump.
         # --- No-op guard ---
         # Runs against whichever baseline we resolved, as long as that baseline
         # has an implementation_hash to compare against. Library always does;
@@ -297,21 +361,15 @@ def checkin(carto, path: str, reason: str = "", version_bump: str = "minor",
     should_bump = baseline_version is not None
 
     # --- Version bump (whenever a baseline exists, local or cloud) ---
+    # Bump from the resolved baseline, NOT the local manifest version. They're
+    # equal in the normal case; when the user pre-bumped meta.version (already
+    # validated above to match this --bump), bumping the baseline lands on the
+    # same value with no double-bump.
     version = meta.get("version", "1.0.0")
     if should_bump:
-        try:
-            from packaging.version import Version as _Version
-            parsed = _Version(version)
-            major, minor, patch = parsed.major, parsed.minor, parsed.micro
-        except Exception:
-            return {"status": "error", "message": f"Cannot bump malformed version '{version}'. Fix widget.json meta.version to X.Y.Z first."}
-        if version_bump == "major":
-            major, minor, patch = major + 1, 0, 0
-        elif version_bump == "minor":
-            minor, patch = minor + 1, 0
-        elif version_bump == "patch":
-            patch += 1
-        new_version = f"{major}.{minor}.{patch}"
+        new_version = _bump_version(baseline_version, version_bump)
+        if new_version is None:
+            return {"status": "error", "message": f"Cannot bump malformed version '{baseline_version}'. Fix the {baseline_source} version to X.Y.Z first."}
     else:
         new_version = version
 

--- a/src/cartograph/cli.py
+++ b/src/cartograph/cli.py
@@ -2487,7 +2487,9 @@ _AGENT_FILENAMES = {
     "codex":        "AGENTS.md",
     "agents":       "AGENTS.md",
     "gemini":       "GEMINI.md",
-    "antigravity":  "GEMINI.md",
+    "antigravity":  "AGENTS.md",
+    "grok":         "AGENTS.md",
+    "agent":        "AGENT.md",
     "cursor":       os.path.join(".cursor", "rules", "cartograph.mdc"),
 }
 
@@ -3607,7 +3609,7 @@ def _build_cli() -> AgentCLI:
             "handler": cmd_setup,
             "args": [
                 {"name": "--agent", "default": None,
-                 "choices": ["claude", "codex", "gemini", "antigravity", "cursor"],
+                 "choices": ["claude", "codex", "gemini", "antigravity", "grok", "agent", "cursor"],
                  "help": "Agent to configure (auto-detected if omitted)"},
                 {"name": "--file", "default": None,
                  "help": "Write to a custom file instead of the agent default"},

--- a/src/cartograph/installer.py
+++ b/src/cartograph/installer.py
@@ -470,6 +470,13 @@ def rename_widget(carto, old_id: str, new_name: str | None,
         return {"status": "error",
                 "message": f"Unknown domain '{new_dom}'. Valid: {sorted(VALID_DOMAINS)}"}
 
+    # The slug becomes a code identifier; reject names that can't be legal
+    # (e.g. leading digit) before moving anything on disk - same rule as create.
+    from cartograph.scaffolding import validate_name_identifier
+    name_error = validate_name_identifier(new_slug, kind="widget")
+    if name_error:
+        return {"status": "error", "message": name_error}
+
     new_id = f"{new_dom}-{new_slug}-{language}"
     if new_id == old_id:
         return {"status": "error",

--- a/src/cartograph/scaffolding/__init__.py
+++ b/src/cartograph/scaffolding/__init__.py
@@ -37,6 +37,55 @@ def _library_notes(language: str, domain: str = "") -> dict:
 from cartograph.validator import VALID_DOMAINS as _VALID_DOMAINS
 
 
+# A widget/blueprint slug becomes a code identifier (Python module, SystemVerilog
+# module, JS export, etc.). Across every supported language an identifier must
+# start with a letter or underscore and contain only letters, digits, and
+# underscores - so the slug, with hyphens mapping to underscores, must follow the
+# same rule. Reject bad names loudly at create time rather than silently mangling
+# them into something the author never chose (e.g. "8b10b-encoder" would become
+# the illegal identifier "8b10b_encoder" and only blow up later at compile time).
+_IDENT_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
+
+
+def _suggest_name(name_base):
+    """Best-effort legal alternative: move digit-leading segments to the end
+    (8b10b-encoder -> encoder-8b10b). Returns None if no clean reorder exists."""
+    parts = [p for p in name_base.split("-") if p]
+    head = [p for p in parts if not p[0].isdigit()]
+    tail = [p for p in parts if p[0].isdigit()]
+    reordered = head + tail
+    if reordered and not reordered[0][0].isdigit():
+        return "-".join(reordered)
+    return None
+
+
+def validate_name_identifier(name_base, kind="widget"):
+    """Return an error message if name_base can't become a legal cross-language
+    identifier, else None. name_base is the slug minus domain/language affixes."""
+    ident = name_base.replace("-", "_")
+    label = kind.capitalize()
+    if not ident:
+        return f"{label} name is empty - provide a name like 'retry-backoff'."
+    if ident[0].isdigit():
+        msg = (
+            f"{label} name '{name_base}' can't start with a digit: it becomes the "
+            f"code identifier '{ident}', which is illegal in every supported "
+            f"language (identifiers must start with a letter)."
+        )
+        suggestion = _suggest_name(name_base)
+        if suggestion:
+            msg += f" Try '{suggestion}' instead."
+        return msg
+    if not _IDENT_RE.match(ident):
+        bad = sorted({c for c in name_base if not (c.isalnum() or c in "-_")})
+        return (
+            f"{label} name '{name_base}' has characters that aren't allowed in a "
+            f"code identifier ({', '.join(repr(c) for c in bad)}). Use only "
+            f"letters, digits, and hyphens."
+        )
+    return None
+
+
 def create_widget(carto, item_id, language, name=None, domain=None, tags=None,
                   target_dir=None, gpu_targets=None, widget_type=None):
     """Scaffold a new widget directory. Returns a status dict."""
@@ -63,6 +112,12 @@ def create_widget(carto, item_id, language, name=None, domain=None, tags=None,
     # Strip domain prefix if already present (avoid backend-backend-...)
     if name_base.startswith(f"{domain}-"):
         name_base = name_base[len(domain) + 1:]
+
+    # Reject names that can't become a legal identifier (e.g. leading digit)
+    # before creating anything on disk.
+    name_error = validate_name_identifier(name_base, kind="widget")
+    if name_error:
+        return {"status": "error", "message": name_error}
 
     # Strip domain prefix from display name if it matches
     if not name:
@@ -164,6 +219,11 @@ def create_blueprint(carto, name, language, target_dir=None, description=None, t
     # Strip trailing language if user typed the full id by accident.
     if slug.endswith(f"-{normalized_lang}"):
         slug = slug[: -len(normalized_lang) - 1]
+
+    # Reject names that can't become a legal identifier (e.g. leading digit).
+    name_error = validate_name_identifier(slug, kind="blueprint")
+    if name_error:
+        return {"status": "error", "message": name_error}
 
     try:
         item_id = compose_blueprint_id(slug, normalized_lang)

--- a/tests/test_checkin.py
+++ b/tests/test_checkin.py
@@ -375,8 +375,10 @@ def _plant_sidecar(install_path, owner="alice",
 
 
 def test_checkin_cloud_version_conflict(carto_tmp, modified_widget):
-    """Sidecar present + cloud says v1.5.0 + local manifest at v1.2.0 must
-    error with 'cloud is v1.5.0' — proves the cloud baseline was consulted."""
+    """Sidecar present + cloud says v1.5.0 + local manifest at v1.2.0 (local
+    BEHIND) must error with the cloud version and direction-aware guidance to
+    `cartograph upgrade` — proves the cloud baseline was consulted and the
+    message names the right rebase command, not `install`."""
     _plant_sidecar(modified_widget)
     with patch("cartograph.cloud.is_available", return_value=True), \
          patch("cartograph.cloud.inspect", return_value={
@@ -384,8 +386,57 @@ def test_checkin_cloud_version_conflict(carto_tmp, modified_widget):
          }):
         result = carto_tmp.checkin(modified_widget, reason="x")
     assert result["status"] == "error"
-    assert "version conflict" in result["message"].lower()
-    assert "cloud is v1.5.0" in result["message"]
+    assert "v1.5.0" in result["message"]
+    assert "v1.2.0" in result["message"]
+    assert "cartograph upgrade" in result["message"]
+    # Must not steer the agent to `install` on an already-installed widget.
+    assert "install" not in result["message"].lower()
+
+
+def _set_local_version(widget_dir, version):
+    manifest_path = os.path.join(widget_dir, "widget.json")
+    with open(manifest_path) as f:
+        data = json.load(f)
+    data["meta"]["version"] = version
+    with open(manifest_path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def test_checkin_manual_bump_passes_when_it_matches(carto_tmp, modified_widget):
+    """Library baseline is v1.2.0. User hand-bumped meta.version to v1.3.0 AND
+    asked for --bump minor (1.2.0 -> 1.3.0). The manual edit lines up with the
+    intent, so checkin passes through and publishes v1.3.0 - not a double-bump
+    to v1.4.0."""
+    _set_local_version(modified_widget, "1.3.0")
+    result = carto_tmp.checkin(modified_widget, reason="x", version_bump="minor")
+    assert result["status"] == "success", result
+    assert result["version"] == "1.3.0"
+
+
+def test_checkin_manual_bump_mismatch_suggests_right_command(carto_tmp, modified_widget):
+    """Baseline v1.2.0, manual v1.3.0 (a minor bump) but the user ran --bump
+    patch (expects v1.2.1). Mismatch must reject AND tell them their edit is a
+    minor bump -> re-run with --bump minor."""
+    _set_local_version(modified_widget, "1.3.0")
+    result = carto_tmp.checkin(modified_widget, reason="x", version_bump="patch")
+    assert result["status"] == "error"
+    assert "1.3.0" in result["message"]
+    assert "1.2.0" in result["message"]
+    assert "--bump minor" in result["message"]
+    # Wrong-direction advice must not leak in from the behind/equal cases.
+    assert "install" not in result["message"].lower()
+    assert "upgrade" not in result["message"].lower()
+
+
+def test_checkin_manual_version_not_a_clean_bump(carto_tmp, modified_widget):
+    """Baseline v1.2.0, manual v1.9.0 is not a clean patch/minor/major bump of
+    the baseline under any --bump level. Reject with guidance to reset
+    meta.version and let --bump set it."""
+    _set_local_version(modified_widget, "1.9.0")
+    result = carto_tmp.checkin(modified_widget, reason="x")
+    assert result["status"] == "error"
+    assert "1.9.0" in result["message"]
+    assert "reset meta.version" in result["message"].lower()
 
 
 def test_checkin_cloud_baseline_overrides_library(carto_tmp, installed_widget):

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -189,3 +189,42 @@ def test_create_spice_widget(carto, tmp_path, monkeypatch):
         tb = f.read()
     assert ".include ../src/my_filter.cir" in tb
     assert "meas" in tb and "ASSERT_PASS" in tb
+
+
+def test_create_rejects_leading_digit_name(carto, tmp_path):
+    """A name that becomes a digit-leading identifier (illegal in every
+    supported language) is rejected loudly, not silently mangled. Regression
+    for the '8b10b-encoder' -> illegal 'module 8b10b_encoder' class of bug."""
+    result = carto.create(
+        "8b10b-encoder",
+        language="systemverilog",
+        domain="rtl",
+        target_dir=str(tmp_path),
+    )
+    assert result.get("status") == "error"
+    assert "digit" in result["message"].lower()
+    # Nothing should be left on disk when the name is rejected.
+    assert not os.path.exists(os.path.join(str(tmp_path), "cg"))
+
+
+def test_create_rejects_illegal_identifier_chars(carto, tmp_path):
+    result = carto.create(
+        "my widget",
+        language="python",
+        domain="backend",
+        target_dir=str(tmp_path),
+    )
+    assert result.get("status") == "error"
+    assert "identifier" in result["message"].lower()
+
+
+def test_create_accepts_reordered_name(carto, tmp_path):
+    """The suggested reorder of a digit-leading name scaffolds cleanly."""
+    result = carto.create(
+        "encoder-8b10b",
+        language="systemverilog",
+        domain="rtl",
+        target_dir=str(tmp_path),
+    )
+    assert result.get("status") == "success"
+    _assert_scaffold(result["path"], ["widget.json", "src", "tests"])


### PR DESCRIPTION
Bundles three independent CLI changes for 0.7.12:

- **Slug validation** - reject widget/blueprint names that can't be legal identifiers (leading digit, illegal chars) at create/rename.
- **checkin manual-bump pass-through** - when meta.version was hand-edited ahead of the baseline, accept it if it matches bump(baseline, --bump); otherwise reject and name the exact --bump command the edit corresponds to. Baseline is source-aware (cloud sidecar wins over library); cloud needs no change.
- **setup agent targets** - add grok/agent, route antigravity to AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)