### PR TITLE
Library-write safety: atomicity, concurrency locking, zip-slip guards

### DIFF
--- a/cg/infra_interprocess_lock_python/examples/example_usage.py
+++ b/cg/infra_interprocess_lock_python/examples/example_usage.py
@@ -1,0 +1,31 @@
+"""Example: serialize a critical section with a cross-process file lock."""
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from src.interprocess_lock import file_lock, LockBusy
+
+with tempfile.TemporaryDirectory() as d:
+    lock_path = os.path.join(d, "library.lock")
+
+    # Blocking acquire: wrap any multi-step mutation so a second process
+    # can't interleave. Waits (via the OS) until the lock is free.
+    with file_lock(lock_path):
+        print("holding the lock; doing a multi-step update safely")
+        # ... rename-swap a directory, write a manifest, archive a version ...
+
+    print("released")
+
+    # Reentrant on one thread: a nested acquire reuses the held lock.
+    with file_lock(lock_path):
+        with file_lock(lock_path):
+            print("nested acquire on the same thread does not deadlock")
+
+    # Non-blocking acquire: surface contention as a clean exception instead
+    # of waiting. A caller can build a timed retry loop around this.
+    try:
+        with file_lock(lock_path, blocking=False):
+            print("acquired without waiting (uncontended)")
+    except LockBusy as e:
+        print(f"would report contention: {e}")

--- a/cg/infra_interprocess_lock_python/src/__init__.py
+++ b/cg/infra_interprocess_lock_python/src/__init__.py
@@ -1,0 +1,1 @@
+# Package marker - add explicit exports here once the public API is stable.

--- a/cg/infra_interprocess_lock_python/src/interprocess_lock.py
+++ b/cg/infra_interprocess_lock_python/src/interprocess_lock.py
@@ -1,0 +1,126 @@
+"""Cross-process advisory file lock, stdlib only.
+
+A context manager that serializes a critical section across separate
+processes (and threads) using an OS advisory lock on a lock file:
+``fcntl.flock`` on POSIX, ``msvcrt.locking`` on Windows. No third-party
+dependency such as ``filelock`` is required.
+
+Scope: this widget owns the *lock mechanism* only - acquire (blocking or
+non-blocking) and release. It deliberately does not implement a
+poll-with-timeout wait: a busy ``sleep`` loop is a caller policy, not a
+primitive, and belongs in the consumer. ``blocking=True`` uses the OS's own
+blocking wait (no spinning); ``blocking=False`` tries once and raises
+:class:`LockBusy` if the lock is already held, which is the hook a caller
+builds a timed retry around.
+
+Two correctness details that trip up naive implementations:
+
+* **Reentrancy is per-thread, keyed by lock path.** POSIX ``flock`` is
+  associated with the open file *description*, so two ``open()`` calls to
+  the same file from one process conflict - a nested acquire on the same
+  call stack would self-deadlock. A thread-local depth counter (keyed by
+  the resolved lock path) lets nested acquires on one thread share the held
+  lock, while a different thread or process still contends through the OS.
+
+* **Windows ``blocking=True`` is not indefinite.** ``msvcrt.locking`` with
+  ``LK_LOCK`` retries for roughly ten seconds and then raises ``OSError``;
+  POSIX ``LOCK_EX`` waits forever. Callers needing a guaranteed bound should
+  use ``blocking=False`` and time their own retries.
+"""
+
+import os
+import threading
+from contextlib import contextmanager
+
+__all__ = ["file_lock", "LockBusy"]
+
+
+class LockBusy(RuntimeError):
+    """Raised by a non-blocking acquire when the lock is already held."""
+
+
+try:
+    import fcntl
+
+    def _acquire(fd: "object", blocking: bool) -> bool:
+        flags = fcntl.LOCK_EX if blocking else fcntl.LOCK_EX | fcntl.LOCK_NB
+        try:
+            fcntl.flock(fd.fileno(), flags)
+            return True
+        except OSError:
+            return False
+
+    def _release(fd: "object") -> None:
+        try:
+            fcntl.flock(fd.fileno(), fcntl.LOCK_UN)
+        except OSError:
+            pass
+
+except ImportError:  # Windows  # pragma: no cover
+    import msvcrt
+
+    def _acquire(fd: "object", blocking: bool) -> bool:
+        mode = msvcrt.LK_LOCK if blocking else msvcrt.LK_NBLCK
+        try:
+            fd.seek(0)
+            msvcrt.locking(fd.fileno(), mode, 1)
+            return True
+        except OSError:
+            return False
+
+    def _release(fd: "object") -> None:
+        try:
+            fd.seek(0)
+            msvcrt.locking(fd.fileno(), msvcrt.LK_UNLCK, 1)
+        except OSError:
+            pass
+
+
+_reentry = threading.local()
+
+
+def _depths() -> dict:
+    d = getattr(_reentry, "depths", None)
+    if d is None:
+        d = {}
+        _reentry.depths = d
+    return d
+
+
+@contextmanager
+def file_lock(lock_path: str, blocking: bool = True):
+    """Hold an exclusive cross-process lock on ``lock_path`` for the block.
+
+    Parameters
+    ----------
+    lock_path:
+        Path to the lock file. Created if missing. Its parent directory must
+        already exist.
+    blocking:
+        ``True`` waits (via the OS) until the lock is free. ``False`` tries
+        once and raises :class:`LockBusy` if another holder has it.
+
+    Reentrant within a single thread for the same ``lock_path``.
+    """
+    key = os.path.abspath(lock_path)
+    depths = _depths()
+    if depths.get(key, 0) > 0:  # already held on this thread
+        depths[key] += 1
+        try:
+            yield
+        finally:
+            depths[key] -= 1
+        return
+
+    fd = open(key, "a+")
+    try:
+        if not _acquire(fd, blocking):
+            raise LockBusy(f"Lock {key!r} is held by another process.")
+        depths[key] = 1
+        try:
+            yield
+        finally:
+            depths[key] = 0
+            _release(fd)
+    finally:
+        fd.close()

--- a/cg/infra_interprocess_lock_python/tests/test_interprocess_lock.py
+++ b/cg/infra_interprocess_lock_python/tests/test_interprocess_lock.py
@@ -1,0 +1,102 @@
+import os
+import sys
+import threading
+import time
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from src.interprocess_lock import file_lock, LockBusy
+
+
+def _lock_path(tmp_path):
+    return str(tmp_path / "x.lock")
+
+
+def test_acquire_and_release_runs_body(tmp_path):
+    ran = []
+    with file_lock(_lock_path(tmp_path)):
+        ran.append(True)
+    assert ran == [True]
+    # Released: a second acquire on a fresh handle succeeds immediately.
+    with file_lock(_lock_path(tmp_path)):
+        pass
+
+
+def test_lock_file_is_created(tmp_path):
+    lp = _lock_path(tmp_path)
+    assert not os.path.exists(lp)
+    with file_lock(lp):
+        assert os.path.exists(lp)
+
+
+def test_reentrant_same_thread(tmp_path):
+    lp = _lock_path(tmp_path)
+    with file_lock(lp):
+        with file_lock(lp):  # nested acquire must not deadlock
+            with file_lock(lp, blocking=False):  # even non-blocking reuses it
+                pass
+
+
+def test_distinct_paths_do_not_share_reentrancy(tmp_path):
+    a = str(tmp_path / "a.lock")
+    b = str(tmp_path / "b.lock")
+    with file_lock(a):
+        with file_lock(b):  # independent lock, freely acquirable
+            pass
+
+
+def test_blocking_serializes_across_threads(tmp_path):
+    lp = _lock_path(tmp_path)
+    order = []
+
+    def worker(tag, hold):
+        with file_lock(lp):  # blocking: waits for the other thread
+            order.append(f"{tag}-in")
+            time.sleep(hold)
+            order.append(f"{tag}-out")
+
+    t1 = threading.Thread(target=worker, args=("a", 0.3))
+    t1.start()
+    time.sleep(0.05)
+    t2 = threading.Thread(target=worker, args=("b", 0.0))
+    t2.start()
+    t1.join()
+    t2.join()
+    assert order == ["a-in", "a-out", "b-in", "b-out"]
+
+
+def test_non_blocking_raises_when_held_by_another_process(tmp_path):
+    """A separate process holds the lock; a non-blocking acquire must raise
+    LockBusy immediately rather than block."""
+    import subprocess
+    import textwrap
+
+    lp = _lock_path(tmp_path)
+    src_dir = os.path.join(os.path.dirname(__file__), "..", "src")
+    holder = textwrap.dedent(f"""
+        import sys, time
+        sys.path.insert(0, {src_dir!r})
+        from interprocess_lock import file_lock
+        with file_lock({lp!r}):
+            print("HELD", flush=True)
+            time.sleep(3)
+    """)
+    proc = subprocess.Popen([sys.executable, "-c", holder],
+                            stdout=subprocess.PIPE, text=True)
+    try:
+        assert proc.stdout.readline().strip() == "HELD"
+        with pytest.raises(LockBusy):
+            with file_lock(lp, blocking=False):
+                pass
+    finally:
+        proc.wait(timeout=10)
+
+
+def test_non_blocking_succeeds_when_free(tmp_path):
+    with file_lock(_lock_path(tmp_path), blocking=False):
+        pass
+
+
+def test_lock_busy_is_runtimeerror():
+    assert issubclass(LockBusy, RuntimeError)

--- a/cg/infra_interprocess_lock_python/widget.json
+++ b/cg/infra_interprocess_lock_python/widget.json
@@ -1,0 +1,31 @@
+{
+  "meta": {
+    "id": "infra-interprocess-lock-python",
+    "name": "Interprocess Lock",
+    "version": "1.0.0",
+    "domain": "infra",
+    "tags": [
+      "lock",
+      "concurrency",
+      "filelock",
+      "flock",
+      "cross-process"
+    ]
+  },
+  "description": "Cross-process advisory file lock as a context manager, stdlib only (fcntl on POSIX, msvcrt on Windows) - no filelock dependency. Serializes a critical section across processes and threads: blocking=True waits via the OS, blocking=False tries once and raises LockBusy so a caller can time its own retries (the poll/timeout policy stays in the consumer, not the primitive). Reentrant per-thread keyed by lock path, so nested acquires on one call stack don't self-deadlock while other threads/processes still contend through the OS.",
+  "tech_stack": {
+    "language": "python",
+    "dependencies": []
+  },
+  "custom_notes": "",
+  "library_notes": {
+    "general": "Single responsibility - one widget does one thing. No global state. No project-specific code, hardcoded paths, credentials, or environment-specific values. Expose variation points as constructor parameters or function arguments - no hardcoded thresholds, colors, sizes, or behavior flags. URLs and endpoints belong in examples as demonstration data, not in src/ - if a widget needs a URL to operate, it must be a parameter the caller provides. All dependencies must be declared in widget.json tech_stack.dependencies. Widgets cannot depend on other widgets - they must be fully self-contained. If you need logic from another widget, copy it into src/ directly. Examples must run and exit cleanly with no user input, no network calls, and no external services or API keys - use fake/hardcoded data. The widget's own declared dependencies are fine and will be installed by the validator before the example runs. Do not modify library_notes - it is managed by Cartograph and will be restored on checkin.",
+    "language": "No project-specific names, identifiers, or terminology anywhere in src/, tests/, or examples/ - use generic names like 'user', 'item', 'value', 'example_org'. A test that references your project's real entity names is contaminated. Use pytest for all tests - no unittest. Type hints required on all public functions. No __init__.py in tests/. No if __name__ == '__main__' blocks in src/ files. Imports ordered: stdlib, third-party, local. ML domain: framework-free (numpy, scikit-learn, plain Python) and API-based inference (HTTP calls to OpenAI, Anthropic, HuggingFace Inference API) work everywhere. Heavy optional frameworks must be pre-installed - Cartograph will not auto-install them. Declare dependencies in widget.json normally; consumers must also have them installed to validate.",
+    "domain": "Accept all paths and hostnames as parameters - never construct paths from hardcoded roots. Config keys, log formats, and health check endpoints must be configurable. Return structured status objects rather than printing; let the caller handle output. Side effects (file writes, process spawns) must be opt-in, not automatic."
+  },
+  "validation": {
+    "engine_version": 1,
+    "validated_at": "2026-06-25T18:39:51.259604+00:00",
+    "runtime": "python 3.14.5"
+  }
+}

--- a/cg/universal_atomic_dir_swap_python/examples/example_usage.py
+++ b/cg/universal_atomic_dir_swap_python/examples/example_usage.py
@@ -1,0 +1,28 @@
+"""Example: replace a directory atomically, never tearing down the live copy."""
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from src.atomic_dir_swap import staged_dir, atomic_swap_dir
+
+with tempfile.TemporaryDirectory() as root:
+    dest = os.path.join(root, "widget")
+    os.makedirs(dest)
+    with open(os.path.join(dest, "v1.txt"), "w") as f:
+        f.write("version 1")
+
+    # Build the whole replacement in a sibling temp dir; it swaps in only on
+    # clean exit. If the block raised, `dest` would keep "version 1".
+    with staged_dir(dest) as build:
+        with open(os.path.join(build, "v2.txt"), "w") as f:
+            f.write("version 2")
+    print("after swap:", sorted(os.listdir(dest)))  # ['v2.txt'] - fully replaced
+
+    # Lower-level: swap a directory you built yourself.
+    other = os.path.join(root, ".cg-new-demo")
+    os.makedirs(other)
+    with open(os.path.join(other, "v3.txt"), "w") as f:
+        f.write("version 3")
+    atomic_swap_dir(other, dest)
+    print("after manual swap:", sorted(os.listdir(dest)))  # ['v3.txt']

--- a/cg/universal_atomic_dir_swap_python/src/__init__.py
+++ b/cg/universal_atomic_dir_swap_python/src/__init__.py
@@ -1,0 +1,1 @@
+# Package marker - add explicit exports here once the public API is stable.

--- a/cg/universal_atomic_dir_swap_python/src/atomic_dir_swap.py
+++ b/cg/universal_atomic_dir_swap_python/src/atomic_dir_swap.py
@@ -1,0 +1,84 @@
+"""Atomically replace a directory by building a sibling and renaming it in.
+
+The hazard this removes: the ``rmtree(dest)`` then ``rebuild`` pattern, which
+destroys the live directory for the entire (failure-prone) duration of the
+rebuild. A crash mid-rebuild leaves ``dest`` deleted-but-not-replaced.
+
+Instead, build the full replacement in a sibling temp directory and swap it in
+with renames. The live copy is moved aside first and restored if the swap
+fails, so a failure never leaves ``dest`` torn down. Because the staged
+directory is a sibling, the swap is a same-filesystem rename (atomic on POSIX
+and Windows), not a copy.
+
+``staged_dir`` is the high-level entry point: a context manager that yields an
+empty build directory and swaps it into place on clean exit, discarding it on
+any exception. ``atomic_swap_dir`` is the lower-level swap if you have already
+built the replacement elsewhere on the same filesystem.
+
+Note: this is whole-directory replacement, not a merge - ``dest`` ends up
+containing exactly the staged contents, nothing from the previous version.
+"""
+
+import os
+import shutil
+import tempfile
+import uuid
+from contextlib import contextmanager
+
+__all__ = ["staged_dir", "atomic_swap_dir"]
+
+
+def atomic_swap_dir(new_dir: str, dest: str) -> None:
+    """Replace ``dest`` with the fully-built ``new_dir`` using renames.
+
+    ``new_dir`` must already contain the complete replacement and live on the
+    same filesystem as ``dest``. The live ``dest`` (if any) is moved aside
+    first and restored if the swap fails, so a crash never leaves ``dest``
+    deleted-but-not-replaced. ``dest``'s parent is created if missing.
+    """
+    dest_abs = os.path.abspath(dest)
+    parent = os.path.dirname(dest_abs)
+    os.makedirs(parent, exist_ok=True)
+
+    backup = None
+    if os.path.lexists(dest_abs):
+        backup = os.path.join(parent, f".cg-old-{uuid.uuid4().hex}")
+        os.replace(dest_abs, backup)  # atomic: live copy moved aside
+    try:
+        os.replace(new_dir, dest_abs)  # atomic: replacement moved into place
+    except BaseException:
+        # Roll back: restore the original if we cleared the slot.
+        if backup is not None and not os.path.lexists(dest_abs):
+            os.replace(backup, dest_abs)
+            backup = None
+        raise
+    finally:
+        if backup is not None:
+            shutil.rmtree(backup, ignore_errors=True)
+
+
+@contextmanager
+def staged_dir(dest: str):
+    """Yield an empty temp dir (sibling of ``dest``) to build a replacement in.
+
+    On clean exit the staged dir is atomically swapped into ``dest``. On any
+    exception it is discarded and ``dest`` is left untouched. The temp dir is a
+    sibling so the swap is a same-filesystem rename.
+    """
+    dest_abs = os.path.abspath(dest)
+    parent = os.path.dirname(dest_abs)
+    os.makedirs(parent, exist_ok=True)
+    tmp = tempfile.mkdtemp(dir=parent, prefix=".cg-new-")
+    try:
+        yield tmp
+    except BaseException:
+        shutil.rmtree(tmp, ignore_errors=True)
+        raise
+    else:
+        try:
+            atomic_swap_dir(tmp, dest_abs)
+        finally:
+            # On a successful swap, tmp was renamed into place; only a failed
+            # swap leaves it behind.
+            if os.path.isdir(tmp):
+                shutil.rmtree(tmp, ignore_errors=True)

--- a/cg/universal_atomic_dir_swap_python/tests/test_atomic_dir_swap.py
+++ b/cg/universal_atomic_dir_swap_python/tests/test_atomic_dir_swap.py
@@ -1,0 +1,99 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from src.atomic_dir_swap import staged_dir, atomic_swap_dir
+
+
+def test_staged_dir_swaps_in_on_success(tmp_path):
+    dest = tmp_path / "widget"
+    dest.mkdir()
+    (dest / "old.txt").write_text("old")
+    with staged_dir(str(dest)) as tmp:
+        with open(os.path.join(tmp, "new.txt"), "w") as f:
+            f.write("new")
+    assert (dest / "new.txt").read_text() == "new"
+    assert not (dest / "old.txt").exists()  # full replacement, not a merge
+
+
+def test_staged_dir_creates_dest_when_absent(tmp_path):
+    dest = tmp_path / "sub" / "widget"  # neither exists yet
+    with staged_dir(str(dest)) as tmp:
+        with open(os.path.join(tmp, "f.txt"), "w") as f:
+            f.write("v")
+    assert (dest / "f.txt").read_text() == "v"
+
+
+def test_staged_dir_leaves_dest_intact_on_failure(tmp_path):
+    dest = tmp_path / "widget"
+    dest.mkdir()
+    (dest / "keep.txt").write_text("important")
+    with pytest.raises(RuntimeError):
+        with staged_dir(str(dest)) as tmp:
+            with open(os.path.join(tmp, "partial.txt"), "w") as f:
+                f.write("half")
+            raise RuntimeError("boom mid-build")
+    assert (dest / "keep.txt").read_text() == "important"
+    assert not (dest / "partial.txt").exists()
+    # No staging crumbs left behind.
+    assert not any(p.name.startswith(".cg-new-") for p in tmp_path.iterdir())
+
+
+def test_atomic_swap_into_empty_slot(tmp_path):
+    dest = tmp_path / "widget"  # does not exist yet
+    new = tmp_path / ".cg-new-y"
+    new.mkdir()
+    (new / "f.txt").write_text("v")
+    atomic_swap_dir(str(new), str(dest))
+    assert (dest / "f.txt").read_text() == "v"
+    assert not new.exists()  # consumed by the swap
+
+
+def test_atomic_swap_replaces_existing(tmp_path):
+    dest = tmp_path / "widget"
+    dest.mkdir()
+    (dest / "a.txt").write_text("a")
+    new = tmp_path / ".cg-new-z"
+    new.mkdir()
+    (new / "b.txt").write_text("b")
+    atomic_swap_dir(str(new), str(dest))
+    assert (dest / "b.txt").read_text() == "b"
+    assert not (dest / "a.txt").exists()
+
+
+def test_atomic_swap_rolls_back_if_replace_fails(tmp_path, monkeypatch):
+    dest = tmp_path / "widget"
+    dest.mkdir()
+    (dest / "keep.txt").write_text("original")
+
+    new = tmp_path / ".cg-new-x"
+    new.mkdir()
+    (new / "new.txt").write_text("replacement")
+
+    import src.atomic_dir_swap as mod
+    real_replace = os.replace
+    calls = {"n": 0}
+
+    def flaky_replace(a, b):
+        calls["n"] += 1
+        if calls["n"] == 2:  # first moves dest aside; fail the second
+            raise OSError("simulated swap failure")
+        return real_replace(a, b)
+
+    monkeypatch.setattr(mod.os, "replace", flaky_replace)
+    with pytest.raises(OSError):
+        atomic_swap_dir(str(new), str(dest))
+    # Rolled back: original content restored, not destroyed.
+    assert (dest / "keep.txt").read_text() == "original"
+
+
+def test_no_leftover_backup_dirs(tmp_path):
+    dest = tmp_path / "widget"
+    dest.mkdir()
+    (dest / "x").write_text("1")
+    with staged_dir(str(dest)) as tmp:
+        with open(os.path.join(tmp, "y"), "w") as f:
+            f.write("2")
+    assert not any(p.name.startswith(".cg-old-") for p in tmp_path.iterdir())

--- a/cg/universal_atomic_dir_swap_python/widget.json
+++ b/cg/universal_atomic_dir_swap_python/widget.json
@@ -1,0 +1,31 @@
+{
+  "meta": {
+    "id": "universal-atomic-dir-swap-python",
+    "name": "Atomic Dir Swap",
+    "version": "1.0.0",
+    "domain": "universal",
+    "tags": [
+      "atomic",
+      "filesystem",
+      "rename",
+      "crash-safe",
+      "directory"
+    ]
+  },
+  "description": "Atomically replace a directory by building the full replacement in a sibling temp dir and renaming it into place, instead of rmtree-then-rebuild (which destroys the live copy for the whole rebuild and corrupts it on a mid-rebuild crash). staged_dir is a context manager that yields a build dir and swaps it in on clean exit, discarding it on any exception; atomic_swap_dir is the lower-level rename swap. The live copy is moved aside and restored if the swap fails, so dest is never left deleted-but-not-replaced. Same-filesystem renames, atomic on POSIX and Windows. Stdlib only.",
+  "tech_stack": {
+    "language": "python",
+    "dependencies": []
+  },
+  "custom_notes": "",
+  "library_notes": {
+    "general": "Single responsibility - one widget does one thing. No global state. No project-specific code, hardcoded paths, credentials, or environment-specific values. Expose variation points as constructor parameters or function arguments - no hardcoded thresholds, colors, sizes, or behavior flags. URLs and endpoints belong in examples as demonstration data, not in src/ - if a widget needs a URL to operate, it must be a parameter the caller provides. All dependencies must be declared in widget.json tech_stack.dependencies. Widgets cannot depend on other widgets - they must be fully self-contained. If you need logic from another widget, copy it into src/ directly. Examples must run and exit cleanly with no user input, no network calls, and no external services or API keys - use fake/hardcoded data. The widget's own declared dependencies are fine and will be installed by the validator before the example runs. Do not modify library_notes - it is managed by Cartograph and will be restored on checkin.",
+    "language": "No project-specific names, identifiers, or terminology anywhere in src/, tests/, or examples/ - use generic names like 'user', 'item', 'value', 'example_org'. A test that references your project's real entity names is contaminated. Use pytest for all tests - no unittest. Type hints required on all public functions. No __init__.py in tests/. No if __name__ == '__main__' blocks in src/ files. Imports ordered: stdlib, third-party, local. ML domain: framework-free (numpy, scikit-learn, plain Python) and API-based inference (HTTP calls to OpenAI, Anthropic, HuggingFace Inference API) work everywhere. Heavy optional frameworks must be pre-installed - Cartograph will not auto-install them. Declare dependencies in widget.json normally; consumers must also have them installed to validate.",
+    "domain": "Use this domain when a widget spans multiple domains or has no clear home \u2014 not because it must be pure. A retry utility, a date formatter, a general-purpose HTTP client all belong here. Expose variation points as parameters. Don't force it into a domain just to avoid universal."
+  },
+  "validation": {
+    "engine_version": 1,
+    "validated_at": "2026-06-25T18:44:10.872490+00:00",
+    "runtime": "python 3.14.5"
+  }
+}

--- a/cg/universal_safe_archive_extract_python/examples/example_usage.py
+++ b/cg/universal_safe_archive_extract_python/examples/example_usage.py
@@ -1,0 +1,34 @@
+"""Example: extract a zip while refusing any member that escapes the target."""
+import io
+import os
+import sys
+import tempfile
+import zipfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from src.safe_archive_extract import safe_extractall, UnsafeArchiveError
+
+
+def _make_zip(members):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, content in members.items():
+            zf.writestr(name, content)
+    buf.seek(0)
+    return buf
+
+
+with tempfile.TemporaryDirectory() as d:
+    dest = os.path.join(d, "out")
+
+    # A well-formed archive extracts normally.
+    with zipfile.ZipFile(_make_zip({"src/main.py": "print(1)", "widget.json": "{}"})) as zf:
+        safe_extractall(zf, dest)
+    print("extracted:", sorted(os.listdir(dest)))
+
+    # A malicious member is refused before anything is written.
+    with zipfile.ZipFile(_make_zip({"../../escape.py": "pwned"})) as zf:
+        try:
+            safe_extractall(zf, dest)
+        except UnsafeArchiveError as e:
+            print("blocked zip-slip:", e)

--- a/cg/universal_safe_archive_extract_python/src/__init__.py
+++ b/cg/universal_safe_archive_extract_python/src/__init__.py
@@ -1,0 +1,1 @@
+# Package marker - add explicit exports here once the public API is stable.

--- a/cg/universal_safe_archive_extract_python/src/safe_archive_extract.py
+++ b/cg/universal_safe_archive_extract_python/src/safe_archive_extract.py
@@ -1,0 +1,56 @@
+"""Zip extraction that refuses members escaping the destination ("zip-slip").
+
+``zipfile.ZipFile.extractall`` will happily write a member named
+``../../etc/foo`` or ``/abs/path`` outside the target directory. When the
+archive comes from an untrusted or partially-trusted source (a registry
+download, a user-supplied import file), that is an arbitrary-write
+vulnerability.
+
+``safe_extractall`` validates every member path against the destination
+*before writing anything*, raising :class:`UnsafeArchiveError` on the first
+member that would escape. Guards absolute paths, ``..`` traversal, and (on
+Windows) drive- and backslash-based escapes by normalizing each member the
+same way the OS will when it joins it onto the destination.
+
+This guards the *path* of each member. Python's ``zipfile`` does not restore
+unix symlinks as symlinks (it writes a regular file with the link text), so
+there is no symlink-escape vector to guard here.
+"""
+
+import os
+import zipfile
+
+__all__ = ["safe_extractall", "safe_extract_zip", "UnsafeArchiveError"]
+
+
+class UnsafeArchiveError(ValueError):
+    """Raised when an archive member would be written outside the destination."""
+
+
+def _assert_members_safe(names, dest_abs: str) -> None:
+    for name in names:
+        target = os.path.abspath(os.path.join(dest_abs, name))
+        if target != dest_abs and not target.startswith(dest_abs + os.sep):
+            raise UnsafeArchiveError(
+                f"Refusing to extract unsafe archive member {name!r}: it "
+                f"escapes the destination directory. The archive may be "
+                f"malicious or corrupt."
+            )
+
+
+def safe_extractall(zf: zipfile.ZipFile, dest: str) -> None:
+    """Extract all members of ``zf`` into ``dest``, rejecting any escape.
+
+    Validates every member path first, so a single unsafe member aborts the
+    whole extraction before anything is written.
+    """
+    dest_abs = os.path.abspath(dest)
+    _assert_members_safe(zf.namelist(), dest_abs)
+    os.makedirs(dest_abs, exist_ok=True)
+    zf.extractall(dest_abs)
+
+
+def safe_extract_zip(zip_path: str, dest: str) -> None:
+    """Open the zip at ``zip_path`` and :func:`safe_extractall` it into ``dest``."""
+    with zipfile.ZipFile(zip_path) as zf:
+        safe_extractall(zf, dest)

--- a/cg/universal_safe_archive_extract_python/src/safe_archive_extract.py
+++ b/cg/universal_safe_archive_extract_python/src/safe_archive_extract.py
@@ -20,14 +20,26 @@ there is no symlink-escape vector to guard here.
 import os
 import zipfile
 
-__all__ = ["safe_extractall", "safe_extract_zip", "UnsafeArchiveError"]
+__all__ = [
+    "safe_extractall",
+    "safe_extract_zip",
+    "assert_members_safe",
+    "UnsafeArchiveError",
+]
 
 
 class UnsafeArchiveError(ValueError):
     """Raised when an archive member would be written outside the destination."""
 
 
-def _assert_members_safe(names, dest_abs: str) -> None:
+def assert_members_safe(names, dest: str) -> None:
+    """Raise :class:`UnsafeArchiveError` if any of ``names`` would escape ``dest``.
+
+    Use this when extracting members selectively (skipping some, renaming
+    others) rather than via :func:`safe_extractall` - validate the whole name
+    list up front, then do the selective writes knowing every target is safe.
+    """
+    dest_abs = os.path.abspath(dest)
     for name in names:
         target = os.path.abspath(os.path.join(dest_abs, name))
         if target != dest_abs and not target.startswith(dest_abs + os.sep):
@@ -45,7 +57,7 @@ def safe_extractall(zf: zipfile.ZipFile, dest: str) -> None:
     whole extraction before anything is written.
     """
     dest_abs = os.path.abspath(dest)
-    _assert_members_safe(zf.namelist(), dest_abs)
+    assert_members_safe(zf.namelist(), dest_abs)
     os.makedirs(dest_abs, exist_ok=True)
     zf.extractall(dest_abs)
 

--- a/cg/universal_safe_archive_extract_python/tests/test_safe_archive_extract.py
+++ b/cg/universal_safe_archive_extract_python/tests/test_safe_archive_extract.py
@@ -1,0 +1,80 @@
+import io
+import os
+import sys
+import zipfile
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from src.safe_archive_extract import (
+    safe_extractall,
+    safe_extract_zip,
+    UnsafeArchiveError,
+)
+
+
+def _zip_bytes(members):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, content in members.items():
+            zf.writestr(name, content)
+    buf.seek(0)
+    return buf
+
+
+def test_allows_normal_members(tmp_path):
+    dest = tmp_path / "out"
+    with zipfile.ZipFile(_zip_bytes({"src/a.py": "x", "widget.json": "{}"})) as zf:
+        safe_extractall(zf, str(dest))
+    assert (dest / "src" / "a.py").read_text() == "x"
+    assert (dest / "widget.json").exists()
+
+
+@pytest.mark.parametrize("evil", [
+    "../escape.py",
+    "../../etc/passwd",
+    "src/../../escape.py",
+    "/abs/escape.py",
+])
+def test_rejects_traversal(tmp_path, evil):
+    dest = tmp_path / "out"
+    with zipfile.ZipFile(_zip_bytes({evil: "pwned"})) as zf:
+        with pytest.raises(UnsafeArchiveError):
+            safe_extractall(zf, str(dest))
+    assert not (tmp_path / "escape.py").exists()
+    assert not (tmp_path.parent / "escape.py").exists()
+
+
+def test_writes_nothing_when_one_member_is_unsafe(tmp_path):
+    dest = tmp_path / "out"
+    with zipfile.ZipFile(_zip_bytes({"ok.py": "x", "../evil.py": "x"})) as zf:
+        with pytest.raises(UnsafeArchiveError):
+            safe_extractall(zf, str(dest))
+    # Guard runs before any extraction, so the safe member isn't written either.
+    assert not (dest / "ok.py").exists()
+
+
+def test_creates_destination_if_missing(tmp_path):
+    dest = tmp_path / "nested" / "out"
+    with zipfile.ZipFile(_zip_bytes({"f.txt": "v"})) as zf:
+        safe_extractall(zf, str(dest))
+    assert (dest / "f.txt").read_text() == "v"
+
+
+def test_safe_extract_zip_from_path(tmp_path):
+    zpath = tmp_path / "a.zip"
+    zpath.write_bytes(_zip_bytes({"f.txt": "hello"}).getvalue())
+    dest = tmp_path / "out"
+    safe_extract_zip(str(zpath), str(dest))
+    assert (dest / "f.txt").read_text() == "hello"
+
+
+def test_safe_extract_zip_rejects_traversal_from_path(tmp_path):
+    zpath = tmp_path / "evil.zip"
+    zpath.write_bytes(_zip_bytes({"../evil.py": "x"}).getvalue())
+    with pytest.raises(UnsafeArchiveError):
+        safe_extract_zip(str(zpath), str(tmp_path / "out"))
+
+
+def test_unsafe_archive_error_is_valueerror():
+    assert issubclass(UnsafeArchiveError, ValueError)

--- a/cg/universal_safe_archive_extract_python/tests/test_safe_archive_extract.py
+++ b/cg/universal_safe_archive_extract_python/tests/test_safe_archive_extract.py
@@ -9,6 +9,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from src.safe_archive_extract import (
     safe_extractall,
     safe_extract_zip,
+    assert_members_safe,
     UnsafeArchiveError,
 )
 
@@ -74,6 +75,16 @@ def test_safe_extract_zip_rejects_traversal_from_path(tmp_path):
     zpath.write_bytes(_zip_bytes({"../evil.py": "x"}).getvalue())
     with pytest.raises(UnsafeArchiveError):
         safe_extract_zip(str(zpath), str(tmp_path / "out"))
+
+
+def test_assert_members_safe_passes_clean_names(tmp_path):
+    assert_members_safe(["src/a.py", "widget.json", "tests/t.py"], str(tmp_path))
+
+
+@pytest.mark.parametrize("evil", ["../x", "/abs/x", "a/../../x"])
+def test_assert_members_safe_rejects_escape(tmp_path, evil):
+    with pytest.raises(UnsafeArchiveError):
+        assert_members_safe(["ok.py", evil], str(tmp_path))
 
 
 def test_unsafe_archive_error_is_valueerror():

--- a/cg/universal_safe_archive_extract_python/widget.json
+++ b/cg/universal_safe_archive_extract_python/widget.json
@@ -2,7 +2,7 @@
   "meta": {
     "id": "universal-safe-archive-extract-python",
     "name": "Safe Archive Extract",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "domain": "universal",
     "tags": [
       "zip",
@@ -25,7 +25,7 @@
   },
   "validation": {
     "engine_version": 1,
-    "validated_at": "2026-06-25T18:46:10.871025+00:00",
+    "validated_at": "2026-06-25T21:42:08.283336+00:00",
     "runtime": "python 3.14.5"
   }
 }

--- a/cg/universal_safe_archive_extract_python/widget.json
+++ b/cg/universal_safe_archive_extract_python/widget.json
@@ -1,0 +1,31 @@
+{
+  "meta": {
+    "id": "universal-safe-archive-extract-python",
+    "name": "Safe Archive Extract",
+    "version": "1.0.0",
+    "domain": "universal",
+    "tags": [
+      "zip",
+      "security",
+      "zip-slip",
+      "extract",
+      "path-traversal"
+    ]
+  },
+  "description": "Zip extraction that refuses members escaping the destination ('zip-slip'). zipfile.extractall will write a member named ../../etc/foo or an absolute path outside the target; with untrusted archives (registry downloads, user imports) that is arbitrary write. safe_extractall validates every member path against the destination before writing anything and raises UnsafeArchiveError on the first escape, guarding ../ traversal, absolute paths, and Windows drive/backslash escapes. safe_extract_zip is a path-based convenience wrapper. Stdlib only.",
+  "tech_stack": {
+    "language": "python",
+    "dependencies": []
+  },
+  "custom_notes": "",
+  "library_notes": {
+    "general": "Single responsibility - one widget does one thing. No global state. No project-specific code, hardcoded paths, credentials, or environment-specific values. Expose variation points as constructor parameters or function arguments - no hardcoded thresholds, colors, sizes, or behavior flags. URLs and endpoints belong in examples as demonstration data, not in src/ - if a widget needs a URL to operate, it must be a parameter the caller provides. All dependencies must be declared in widget.json tech_stack.dependencies. Widgets cannot depend on other widgets - they must be fully self-contained. If you need logic from another widget, copy it into src/ directly. Examples must run and exit cleanly with no user input, no network calls, and no external services or API keys - use fake/hardcoded data. The widget's own declared dependencies are fine and will be installed by the validator before the example runs. Do not modify library_notes - it is managed by Cartograph and will be restored on checkin.",
+    "language": "No project-specific names, identifiers, or terminology anywhere in src/, tests/, or examples/ - use generic names like 'user', 'item', 'value', 'example_org'. A test that references your project's real entity names is contaminated. Use pytest for all tests - no unittest. Type hints required on all public functions. No __init__.py in tests/. No if __name__ == '__main__' blocks in src/ files. Imports ordered: stdlib, third-party, local. ML domain: framework-free (numpy, scikit-learn, plain Python) and API-based inference (HTTP calls to OpenAI, Anthropic, HuggingFace Inference API) work everywhere. Heavy optional frameworks must be pre-installed - Cartograph will not auto-install them. Declare dependencies in widget.json normally; consumers must also have them installed to validate.",
+    "domain": "Use this domain when a widget spans multiple domains or has no clear home \u2014 not because it must be pure. A retry utility, a date formatter, a general-purpose HTTP client all belong here. Expose variation points as parameters. Don't force it into a domain just to avoid universal."
+  },
+  "validation": {
+    "engine_version": 1,
+    "validated_at": "2026-06-25T18:46:10.871025+00:00",
+    "runtime": "python 3.14.5"
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cartograph-cli"
-version = "0.7.12"
+version = "0.7.13"
 description = "Widget library manager for AI agents — CLI"
 readme = "README.md"
 license = "MIT"

--- a/src/cartograph/checkin.py
+++ b/src/cartograph/checkin.py
@@ -30,7 +30,7 @@ import shutil
 
 from .engine import semver_key as _semver_key
 from .languages import get_engine
-from .safefs import library_lock, staged_dir, LockTimeout
+from .safefs import widget_lock, staged_dir, LockTimeout
 from .scaffolding import _library_notes as _canonical_library_notes
 from .validation_stamp import is_stamp_valid, write_stamp, STAMP_FILE as _STAMP_FILE
 
@@ -425,13 +425,14 @@ def checkin(carto, path: str, reason: str = "", version_bump: str = "minor",
         "history", "changelog.json", _STAMP_FILE, ".cartograph_source",
     )
 
-    # All shared-library mutation happens under the library lock, and the new
-    # widget directory is built in a staged sibling then swapped in atomically:
-    # the live library entry is never torn down before its replacement is ready,
-    # and a concurrent checkin/sync/delete can't interleave.
+    # Mutation is scoped to THIS widget's lock, and the new widget directory is
+    # built in a staged sibling then swapped in atomically: the live entry is
+    # never torn down before its replacement is ready, and a concurrent
+    # checkin/sync/delete of the SAME widget can't interleave - while checkins
+    # of OTHER widgets proceed in parallel.
     diff = None
     try:
-        with library_lock(carto.library_path):
+        with widget_lock(carto.library_path, item_id):
             diff = carto._diff_against_library(path, item_id) if is_update else None
             with staged_dir(dest_path) as staged:
                 # 1. working copy -> staged (history/changelog/stamp/sidecar excluded)

--- a/src/cartograph/checkin.py
+++ b/src/cartograph/checkin.py
@@ -30,6 +30,7 @@ import shutil
 
 from .engine import semver_key as _semver_key
 from .languages import get_engine
+from .safefs import library_lock, staged_dir, LockTimeout
 from .scaffolding import _library_notes as _canonical_library_notes
 from .validation_stamp import is_stamp_valid, write_stamp, STAMP_FILE as _STAMP_FILE
 
@@ -56,6 +57,15 @@ def _bump_version(version: str, kind: str) -> str | None:
     elif kind == "patch":
         patch += 1
     return f"{major}.{minor}.{patch}"
+
+
+class _CheckinAbort(Exception):
+    """Internal: abort the staged library write and return a clean error.
+
+    Raised inside the staged build so the exception unwinds ``staged_dir``
+    (discarding the half-built directory, leaving the library untouched) and is
+    converted to an error result by the caller.
+    """
 
 
 def _artifact_skip_set(language: str | None) -> set[str]:
@@ -386,72 +396,15 @@ def checkin(carto, path: str, reason: str = "", version_bump: str = "minor",
             validation_block["runtime"] = rv
     data["validation"] = validation_block
 
-    with open(manifest_path, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2)
-
     # --- Determine destination ---
     if is_update:
         dest_path = widget_record["path"]
     else:
-        folder_name = item_id
-        dest_path = os.path.join(carto.library_path, folder_name)
+        dest_path = os.path.join(carto.library_path, item_id)
         if os.path.exists(dest_path):
             return {"status": "error",
                     "message": f"Directory already exists but widget is not in index: {dest_path}"}
 
-    # --- Archive current library version to history/ ---
-    if is_update and os.path.exists(dest_path):
-        old_version = widget_record.get("version", "unknown")
-        history_path = os.path.join(dest_path, "history", old_version)
-        if os.path.exists(history_path):
-            shutil.rmtree(history_path)
-        os.makedirs(history_path, exist_ok=True)
-        artifact_skips = _artifact_skip_set(language)
-        ignore = shutil.ignore_patterns(
-            *artifact_skips, "*.pyc",
-            "history", "changelog.json", _STAMP_FILE, ".cartograph_source",
-        )
-        per_item_skips = artifact_skips | {
-            "history", "changelog.json", _STAMP_FILE, ".cartograph_source",
-        }
-        for item in os.listdir(dest_path):
-            if item in per_item_skips:
-                continue
-            src = os.path.join(dest_path, item)
-            dst = os.path.join(history_path, item)
-            if os.path.isdir(src):
-                shutil.copytree(src, dst, ignore=ignore)
-            else:
-                shutil.copy2(src, dst)
-
-    # --- Restore library_notes before copying (agent edits ignored) ---
-    try:
-        _restore_library_notes(manifest_path)
-    except Exception as e:
-        return {"status": "error", "message": f"Could not restore canonical library_notes: {e}"}
-
-    # --- Copy working copy → library (never move — leave source intact) ---
-    artifact_skips = _artifact_skip_set(language)
-    ignore = shutil.ignore_patterns(
-        *artifact_skips, "*.pyc", ".cartograph_source",
-    )
-    per_item_skips = artifact_skips | {
-        "history", "changelog.json", _STAMP_FILE, ".cartograph_source",
-    }
-    os.makedirs(dest_path, exist_ok=True)
-    for item in os.listdir(path):
-        if item in per_item_skips:
-            continue
-        src = os.path.join(path, item)
-        dst = os.path.join(dest_path, item)
-        if os.path.isdir(src):
-            if os.path.exists(dst):
-                shutil.rmtree(dst)
-            shutil.copytree(src, dst, ignore=ignore)
-        else:
-            shutil.copy2(src, dst)
-
-    # --- Changelog ---
     changelog_entry = {
         "version": new_version,
         "reason": reason or ("No reason provided" if is_update else "Initial release"),
@@ -460,27 +413,119 @@ def checkin(carto, path: str, reason: str = "", version_bump: str = "minor",
     if override_warnings and override_reason:
         changelog_entry["override_reason"] = override_reason
 
-    changelog_path = os.path.join(dest_path, "changelog.json")
-    changelog = []
-    if os.path.exists(changelog_path):
-        try:
-            with open(changelog_path, encoding="utf-8") as f:
-                changelog = json.load(f)
-        except Exception:
-            pass
-    changelog.insert(0, changelog_entry)
-    with open(changelog_path, "w", encoding="utf-8") as f:
-        json.dump(changelog, f, indent=2)
+    artifact_skips = _artifact_skip_set(language)
+    # Files that live only in the library (not the working copy) and are carried
+    # over / regenerated rather than copied from source.
+    carry_skips = artifact_skips | {
+        "history", "changelog.json", _STAMP_FILE, ".cartograph_source",
+    }
+    copy_ignore = shutil.ignore_patterns(*artifact_skips, "*.pyc", ".cartograph_source")
+    snapshot_ignore = shutil.ignore_patterns(
+        *artifact_skips, "*.pyc",
+        "history", "changelog.json", _STAMP_FILE, ".cartograph_source",
+    )
 
-    # --- Diff for AI review ---
-    diff = carto._diff_against_library(path, item_id) if is_update else None
+    # All shared-library mutation happens under the library lock, and the new
+    # widget directory is built in a staged sibling then swapped in atomically:
+    # the live library entry is never torn down before its replacement is ready,
+    # and a concurrent checkin/sync/delete can't interleave.
+    diff = None
+    try:
+        with library_lock(carto.library_path):
+            diff = carto._diff_against_library(path, item_id) if is_update else None
+            with staged_dir(dest_path) as staged:
+                # 1. working copy -> staged (history/changelog/stamp/sidecar excluded)
+                for item in os.listdir(path):
+                    if item in carry_skips:
+                        continue
+                    src = os.path.join(path, item)
+                    dst = os.path.join(staged, item)
+                    if os.path.isdir(src):
+                        shutil.copytree(src, dst, ignore=copy_ignore)
+                    else:
+                        shutil.copy2(src, dst)
 
-    # --- Write fresh stamp at library path (files are in final state) ---
-    if engine:
-        try:
-            write_stamp(dest_path, language, engine)
-        except OSError as e:
-            log.warning("Could not write validation stamp after checkin: %s", e)
+                # 2. canonical library_notes into the staged manifest, then read
+                #    it back so the source manifest written later matches exactly.
+                staged_manifest = os.path.join(staged, "widget.json")
+                with open(staged_manifest, "w", encoding="utf-8") as f:
+                    json.dump(data, f, indent=2)
+                try:
+                    _restore_library_notes(staged_manifest)
+                except Exception as e:
+                    # Abort cleanly: the exception unwinds staged_dir (which
+                    # discards the half-built dir, leaving the library intact)
+                    # and is turned into an error result below.
+                    raise _CheckinAbort(
+                        f"Could not restore canonical library_notes: {e}") from e
+                with open(staged_manifest, encoding="utf-8") as f:
+                    data = json.load(f)
+
+                # 3. carry history + sidecar from the existing library entry and
+                #    archive the previous version into history/<old_version>/.
+                old_changelog = []
+                if is_update and os.path.exists(dest_path):
+                    old_history = os.path.join(dest_path, "history")
+                    if os.path.isdir(old_history):
+                        shutil.copytree(old_history, os.path.join(staged, "history"))
+                    old_version = widget_record.get("version", "unknown")
+                    snap = os.path.join(staged, "history", old_version)
+                    if os.path.exists(snap):
+                        shutil.rmtree(snap)
+                    os.makedirs(snap, exist_ok=True)
+                    for item in os.listdir(dest_path):
+                        if item in carry_skips:
+                            continue
+                        s = os.path.join(dest_path, item)
+                        d = os.path.join(snap, item)
+                        if os.path.isdir(s):
+                            shutil.copytree(s, d, ignore=snapshot_ignore)
+                        else:
+                            shutil.copy2(s, d)
+                    sidecar = os.path.join(dest_path, ".cartograph_source")
+                    if os.path.exists(sidecar):
+                        shutil.copy2(sidecar, os.path.join(staged, ".cartograph_source"))
+
+                    # Prior changelog: preserve a corrupt one (don't silently
+                    # drop the history) by parking it next to the new changelog.
+                    clog = os.path.join(dest_path, "changelog.json")
+                    if os.path.exists(clog):
+                        try:
+                            with open(clog, encoding="utf-8") as f:
+                                loaded = json.load(f)
+                            if not isinstance(loaded, list):
+                                raise ValueError("changelog.json is not a list")
+                            old_changelog = loaded
+                        except Exception as e:
+                            log.warning("Existing changelog.json is unreadable (%s); "
+                                        "preserving it as changelog.json.corrupt", e)
+                            shutil.copy2(clog, os.path.join(staged, "changelog.json.corrupt"))
+
+                # 4. changelog (newest first)
+                changelog = [changelog_entry, *old_changelog]
+                with open(os.path.join(staged, "changelog.json"), "w", encoding="utf-8") as f:
+                    json.dump(changelog, f, indent=2)
+
+                # 5. stamp over the staged (final) files
+                if engine:
+                    try:
+                        write_stamp(staged, language, engine)
+                    except OSError as e:
+                        log.warning("Could not write validation stamp after checkin: %s", e)
+            # staged_dir swapped the new directory into dest_path atomically here.
+
+            # The library write succeeded; only now reflect the bump in the
+            # source manifest. Done last so a mid-write failure leaves source and
+            # library consistent at the old version rather than desynced.
+            try:
+                with open(manifest_path, "w", encoding="utf-8") as f:
+                    json.dump(data, f, indent=2)
+            except OSError as e:
+                log.warning("Library updated but could not update source manifest: %s", e)
+    except LockTimeout as e:
+        return {"status": "error", "message": str(e)}
+    except _CheckinAbort as e:
+        return {"status": "error", "message": str(e)}
 
     # --- Reload library so the in-memory index reflects the new widget ---
     carto.reload()

--- a/src/cartograph/cli.py
+++ b/src/cartograph/cli.py
@@ -1687,8 +1687,14 @@ def cmd_cloud_adopt(args):
             })
         except Exception:
             pass  # unreadable sidecar - overwrite it
-    with open(sidecar_path, "w", encoding="utf-8") as f:
-        json.dump(sidecar, f)
+    from .engine import LIBRARY_PATH
+    from .safefs import library_lock, LockTimeout
+    try:
+        with library_lock(LIBRARY_PATH):
+            with open(sidecar_path, "w", encoding="utf-8") as f:
+                json.dump(sidecar, f)
+    except LockTimeout as e:
+        err({"error": str(e)})
 
     cloud_ver = cloud_widget.get("version", "?")
     print(f"\n  Adopted: {local_id} linked to {cloud_ref} v{cloud_ver}")
@@ -2597,6 +2603,7 @@ def cmd_import(args):
     """
     import zipfile
     from .engine import LIBRARY_PATH
+    from .safefs import assert_members_safe, UnsafeArchiveError, library_lock, LockTimeout
 
     path = args.path
     if not os.path.isfile(path):
@@ -2605,44 +2612,67 @@ def cmd_import(args):
     if not zipfile.is_zipfile(path):
         err({"error": f"Not a valid zip file: {path}"})
 
-    with zipfile.ZipFile(path, "r") as zf:
-        names = zf.namelist()
-        manifests = [n for n in names if n.endswith("widget.json") and n.count("/") == 1]
-        if not manifests:
-            err({"error": "Zip does not appear to contain a widget library (no widget.json files found)."})
-
-        os.makedirs(LIBRARY_PATH, exist_ok=True)
-
-        imported_widget_ids = set()
-        imported = 0
-        skipped = 0
-        for name in names:
-            dest = os.path.join(LIBRARY_PATH, name)
-            if name.endswith("/"):
-                os.makedirs(dest, exist_ok=True)
-                continue
-            if os.path.exists(dest) and not getattr(args, "force", False):
-                skipped += 1
-                continue
-            os.makedirs(os.path.dirname(dest), exist_ok=True)
-            with zf.open(name) as src, open(dest, "wb") as dst:
-                dst.write(src.read())
-            imported += 1
-            # Track which top-level widget dirs we touched, so we know
-            # what to gate after extraction.
-            head = name.split("/", 1)[0]
-            if head and "/" in name:
-                imported_widget_ids.add(head)
-
-    # Integrity gate: walk each freshly-imported widget. Accept stamped
-    # ones, validate-and-stamp unstamped ones, quarantine failures.
     from .validation_stamp import has_valid_stamp, write_stamp
     from .languages import get_engine
     from .validator import validate_item
     import shutil
 
     quarantine_dir = os.path.join(LIBRARY_PATH, ".quarantine")
-    carto = _carto()
+
+    try:
+        # The import zip can come from anywhere; serialize the whole extract +
+        # gate under the library lock so a concurrent checkin/sync can't
+        # interleave, and refuse zip-slip members before writing anything.
+        with library_lock(LIBRARY_PATH):
+            with zipfile.ZipFile(path, "r") as zf:
+                names = zf.namelist()
+                manifests = [n for n in names if n.endswith("widget.json") and n.count("/") == 1]
+                if not manifests:
+                    err({"error": "Zip does not appear to contain a widget library (no widget.json files found)."})
+                # Zip-slip guard: validate every member up front, before any write.
+                assert_members_safe(names, LIBRARY_PATH)
+
+                os.makedirs(LIBRARY_PATH, exist_ok=True)
+
+                imported_widget_ids = set()
+                imported = 0
+                skipped = 0
+                for name in names:
+                    dest = os.path.join(LIBRARY_PATH, name)
+                    if name.endswith("/"):
+                        os.makedirs(dest, exist_ok=True)
+                        continue
+                    if os.path.exists(dest) and not getattr(args, "force", False):
+                        skipped += 1
+                        continue
+                    os.makedirs(os.path.dirname(dest), exist_ok=True)
+                    with zf.open(name) as src, open(dest, "wb") as dst:
+                        dst.write(src.read())
+                    imported += 1
+                    # Track which top-level widget dirs we touched, so we know
+                    # what to gate after extraction.
+                    head = name.split("/", 1)[0]
+                    if head and "/" in name:
+                        imported_widget_ids.add(head)
+
+            # Integrity gate: walk each freshly-imported widget. Accept stamped
+            # ones, validate-and-stamp unstamped ones, quarantine failures.
+            carto = _carto()
+            gate_results = _import_integrity_gate(
+                carto, imported_widget_ids, LIBRARY_PATH, quarantine_dir,
+                has_valid_stamp, write_stamp, get_engine, validate_item)
+    except UnsafeArchiveError as e:
+        err({"error": str(e)})
+    except LockTimeout as e:
+        err({"error": str(e)})
+
+    return _import_summary(
+        imported, imported_widget_ids, quarantine_dir, skipped, gate_results)
+
+
+def _import_integrity_gate(carto, imported_widget_ids, LIBRARY_PATH,
+                           quarantine_dir, has_valid_stamp, write_stamp,
+                           get_engine, validate_item):
     accepted_stamped = []
     accepted_revalidated = []
     quarantined = []
@@ -2688,6 +2718,12 @@ def cmd_import(args):
 
     # Reload so any new widgets show up.
     _carto()
+    return accepted_stamped, accepted_revalidated, quarantined
+
+
+def _import_summary(imported, imported_widget_ids, quarantine_dir, skipped,
+                    gate_results):
+    accepted_stamped, accepted_revalidated, quarantined = gate_results
     print(f"\n  Imported {imported} files from {len(imported_widget_ids)} widget(s).")
     if accepted_stamped:
         print(f"    accepted (stamp valid): {len(accepted_stamped)}")
@@ -2874,6 +2910,10 @@ def cmd_sync(args):
             print(f"ok → v{result.get('version', '?')}")
 
     # Execute pulls — download and extract into library
+    from .safefs import (
+        safe_extractall, staged_dir, library_lock, LockTimeout,
+        UnsafeArchiveError,
+    )
     for wid, detail in pulls:
         remote = cloud_by_id[wid]
         owner = remote.get("owner", handle)
@@ -2882,15 +2922,18 @@ def cmd_sync(args):
         if "error" in result:
             print(f"FAILED: {result['error']}")
             continue
-        # Extract into library, overwriting existing
+        # Extract registry bytes zip-slip-safely into a staged dir, then swap it
+        # in atomically under the library lock - the old copy is never torn down
+        # before the new one is fully extracted, and a bad member writes nothing.
         dest = os.path.join(carto.library_path, wid)
         try:
-            if os.path.exists(dest):
-                shutil.rmtree(dest)
-            os.makedirs(dest, exist_ok=True)
-            with zipfile.ZipFile(BytesIO(result["zip_bytes"])) as zf:
-                zf.extractall(dest)
+            with library_lock(carto.library_path):
+                with staged_dir(dest) as staging:
+                    with zipfile.ZipFile(BytesIO(result["zip_bytes"])) as zf:
+                        safe_extractall(zf, staging)
             print(f"ok → v{result.get('version', '?')}")
+        except (UnsafeArchiveError, LockTimeout) as e:
+            print(f"FAILED: {e}")
         except Exception as e:
             print(f"FAILED: {e}")
 

--- a/src/cartograph/cli.py
+++ b/src/cartograph/cli.py
@@ -1688,9 +1688,9 @@ def cmd_cloud_adopt(args):
         except Exception:
             pass  # unreadable sidecar - overwrite it
     from .engine import LIBRARY_PATH
-    from .safefs import library_lock, LockTimeout
+    from .safefs import widget_lock, LockTimeout
     try:
-        with library_lock(LIBRARY_PATH):
+        with widget_lock(LIBRARY_PATH, widget.get("id", local_id)):
             with open(sidecar_path, "w", encoding="utf-8") as f:
                 json.dump(sidecar, f)
     except LockTimeout as e:
@@ -2603,7 +2603,7 @@ def cmd_import(args):
     """
     import zipfile
     from .engine import LIBRARY_PATH
-    from .safefs import assert_members_safe, UnsafeArchiveError, library_lock, LockTimeout
+    from .safefs import assert_members_safe, UnsafeArchiveError, widget_lock, LockTimeout
 
     path = args.path
     if not os.path.isfile(path):
@@ -2619,48 +2619,61 @@ def cmd_import(args):
 
     quarantine_dir = os.path.join(LIBRARY_PATH, ".quarantine")
 
+    imported = 0
+    skipped = 0
+    imported_widget_ids = set()
+    gate_results = ([], [], [])
     try:
-        # The import zip can come from anywhere; serialize the whole extract +
-        # gate under the library lock so a concurrent checkin/sync can't
-        # interleave, and refuse zip-slip members before writing anything.
-        with library_lock(LIBRARY_PATH):
-            with zipfile.ZipFile(path, "r") as zf:
-                names = zf.namelist()
-                manifests = [n for n in names if n.endswith("widget.json") and n.count("/") == 1]
-                if not manifests:
-                    err({"error": "Zip does not appear to contain a widget library (no widget.json files found)."})
-                # Zip-slip guard: validate every member up front, before any write.
-                assert_members_safe(names, LIBRARY_PATH)
+        with zipfile.ZipFile(path, "r") as zf:
+            names = zf.namelist()
+            manifests = [n for n in names if n.endswith("widget.json") and n.count("/") == 1]
+            if not manifests:
+                err({"error": "Zip does not appear to contain a widget library (no widget.json files found)."})
+            # Zip-slip guard: validate every member up front, before any write.
+            assert_members_safe(names, LIBRARY_PATH)
+            os.makedirs(LIBRARY_PATH, exist_ok=True)
 
-                os.makedirs(LIBRARY_PATH, exist_ok=True)
+            # Group members by top-level widget dir so each widget is written
+            # and gated under its OWN lock - importing widget A doesn't block a
+            # concurrent checkin of widget B, only of widget A.
+            by_widget = {}
+            for name in names:
+                head = name.split("/", 1)[0]
+                if head:
+                    by_widget.setdefault(head, []).append(name)
 
-                imported_widget_ids = set()
-                imported = 0
-                skipped = 0
-                for name in names:
-                    dest = os.path.join(LIBRARY_PATH, name)
-                    if name.endswith("/"):
-                        os.makedirs(dest, exist_ok=True)
-                        continue
-                    if os.path.exists(dest) and not getattr(args, "force", False):
-                        skipped += 1
-                        continue
-                    os.makedirs(os.path.dirname(dest), exist_ok=True)
-                    with zf.open(name) as src, open(dest, "wb") as dst:
-                        dst.write(src.read())
-                    imported += 1
-                    # Track which top-level widget dirs we touched, so we know
-                    # what to gate after extraction.
-                    head = name.split("/", 1)[0]
-                    if head and "/" in name:
-                        imported_widget_ids.add(head)
-
-            # Integrity gate: walk each freshly-imported widget. Accept stamped
-            # ones, validate-and-stamp unstamped ones, quarantine failures.
             carto = _carto()
-            gate_results = _import_integrity_gate(
-                carto, imported_widget_ids, LIBRARY_PATH, quarantine_dir,
-                has_valid_stamp, write_stamp, get_engine, validate_item)
+            force = getattr(args, "force", False)
+            accepted_stamped, accepted_revalidated, quarantined = [], [], []
+            for head, members in sorted(by_widget.items()):
+                with widget_lock(LIBRARY_PATH, head):
+                    for name in members:
+                        dest = os.path.join(LIBRARY_PATH, name)
+                        if name.endswith("/"):
+                            os.makedirs(dest, exist_ok=True)
+                            continue
+                        if os.path.exists(dest) and not force:
+                            skipped += 1
+                            continue
+                        os.makedirs(os.path.dirname(dest), exist_ok=True)
+                        with zf.open(name) as src, open(dest, "wb") as dst:
+                            dst.write(src.read())
+                        imported += 1
+                        if "/" in name:
+                            imported_widget_ids.add(head)
+                    # Gate THIS widget under its lock.
+                    if head in imported_widget_ids:
+                        category, info = _gate_one_widget(
+                            carto, head, LIBRARY_PATH, quarantine_dir,
+                            has_valid_stamp, write_stamp, get_engine, validate_item)
+                        if category == "stamped":
+                            accepted_stamped.append(info)
+                        elif category == "revalidated":
+                            accepted_revalidated.append(info)
+                        elif category == "quarantined":
+                            quarantined.append(info)
+            _carto()  # reload so new widgets show up
+            gate_results = (accepted_stamped, accepted_revalidated, quarantined)
     except UnsafeArchiveError as e:
         err({"error": str(e)})
     except LockTimeout as e:
@@ -2670,55 +2683,50 @@ def cmd_import(args):
         imported, imported_widget_ids, quarantine_dir, skipped, gate_results)
 
 
-def _import_integrity_gate(carto, imported_widget_ids, LIBRARY_PATH,
-                           quarantine_dir, has_valid_stamp, write_stamp,
-                           get_engine, validate_item):
-    accepted_stamped = []
-    accepted_revalidated = []
-    quarantined = []
+def _gate_one_widget(carto, wid_dir, LIBRARY_PATH, quarantine_dir,
+                     has_valid_stamp, write_stamp, get_engine, validate_item):
+    """Integrity-gate a single freshly-imported widget.
 
-    for wid_dir in sorted(imported_widget_ids):
-        widget_path = os.path.join(LIBRARY_PATH, wid_dir)
-        manifest_path = os.path.join(widget_path, "widget.json")
-        if not os.path.isfile(manifest_path):
-            continue
-        try:
-            with open(manifest_path, encoding="utf-8") as f:
-                data = json.load(f)
-            language = data.get("tech_stack", {}).get("language", "unknown")
-            if isinstance(language, list):
-                language = language[0] if language else "unknown"
-        except Exception as e:
-            quarantined.append({"id": wid_dir, "reason": f"unreadable manifest: {e}"})
-            _quarantine_widget(widget_path, quarantine_dir, f"unreadable manifest: {e}")
-            continue
+    Returns ``(category, info)`` where category is one of "stamped",
+    "revalidated", "quarantined", or "skipped" (no manifest). Caller holds the
+    widget's lock.
+    """
+    widget_path = os.path.join(LIBRARY_PATH, wid_dir)
+    manifest_path = os.path.join(widget_path, "widget.json")
+    if not os.path.isfile(manifest_path):
+        return "skipped", wid_dir
+    try:
+        with open(manifest_path, encoding="utf-8") as f:
+            data = json.load(f)
+        language = data.get("tech_stack", {}).get("language", "unknown")
+        if isinstance(language, list):
+            language = language[0] if language else "unknown"
+    except Exception as e:
+        reason = f"unreadable manifest: {e}"
+        _quarantine_widget(widget_path, quarantine_dir, reason)
+        return "quarantined", {"id": wid_dir, "reason": reason}
 
-        if has_valid_stamp(widget_path, language):
-            accepted_stamped.append(wid_dir)
-            continue
+    if has_valid_stamp(widget_path, language):
+        return "stamped", wid_dir
 
-        engine = get_engine(language)
-        if engine is None:
-            quarantined.append({"id": wid_dir, "reason": f"no engine for language {language!r}"})
-            _quarantine_widget(widget_path, quarantine_dir, f"no engine for language {language!r}")
-            continue
+    engine = get_engine(language)
+    if engine is None:
+        reason = f"no engine for language {language!r}"
+        _quarantine_widget(widget_path, quarantine_dir, reason)
+        return "quarantined", {"id": wid_dir, "reason": reason}
 
-        result = validate_item(carto, widget_path)
-        if isinstance(result, dict) and result.get("status") == "error":
-            reason = result.get("message", "validation failed")
-            quarantined.append({"id": wid_dir, "reason": reason})
-            _quarantine_widget(widget_path, quarantine_dir, reason)
-            continue
-        try:
-            write_stamp(widget_path, language, engine, test_results=None)
-            accepted_revalidated.append(wid_dir)
-        except Exception as e:
-            quarantined.append({"id": wid_dir, "reason": f"stamp write failed: {e}"})
-            _quarantine_widget(widget_path, quarantine_dir, f"stamp write failed: {e}")
-
-    # Reload so any new widgets show up.
-    _carto()
-    return accepted_stamped, accepted_revalidated, quarantined
+    result = validate_item(carto, widget_path)
+    if isinstance(result, dict) and result.get("status") == "error":
+        reason = result.get("message", "validation failed")
+        _quarantine_widget(widget_path, quarantine_dir, reason)
+        return "quarantined", {"id": wid_dir, "reason": reason}
+    try:
+        write_stamp(widget_path, language, engine, test_results=None)
+        return "revalidated", wid_dir
+    except Exception as e:
+        reason = f"stamp write failed: {e}"
+        _quarantine_widget(widget_path, quarantine_dir, reason)
+        return "quarantined", {"id": wid_dir, "reason": reason}
 
 
 def _import_summary(imported, imported_widget_ids, quarantine_dir, skipped,
@@ -2911,7 +2919,7 @@ def cmd_sync(args):
 
     # Execute pulls — download and extract into library
     from .safefs import (
-        safe_extractall, staged_dir, library_lock, LockTimeout,
+        safe_extractall, staged_dir, widget_lock, LockTimeout,
         UnsafeArchiveError,
     )
     for wid, detail in pulls:
@@ -2927,7 +2935,7 @@ def cmd_sync(args):
         # before the new one is fully extracted, and a bad member writes nothing.
         dest = os.path.join(carto.library_path, wid)
         try:
-            with library_lock(carto.library_path):
+            with widget_lock(carto.library_path, wid):
                 with staged_dir(dest) as staging:
                     with zipfile.ZipFile(BytesIO(result["zip_bytes"])) as zf:
                         safe_extractall(zf, staging)

--- a/src/cartograph/installer.py
+++ b/src/cartograph/installer.py
@@ -118,9 +118,10 @@ def _install_from_cloud(widget_id, dest_path, registry_url=None, owner_hint=None
     version = result.get("version", "0.0.0")
     governance = result.get("governance")  # from X-Widget-Governance header, None if server doesn't send it
     try:
+        from .safefs import safe_extractall
         os.makedirs(dest_path, exist_ok=True)
         with zipfile.ZipFile(BytesIO(zip_bytes)) as zf:
-            zf.extractall(dest_path)
+            safe_extractall(zf, dest_path)
 
         # Write sidecar: provenance (where/who/terms) for checkin routing
         from .auth import get_registry_url as _public_url
@@ -350,8 +351,12 @@ def delete_from_library(carto, widget_id, confirm=False):
         }
 
     widget_path = widget["path"]
+    from .safefs import library_lock, LockTimeout
     try:
-        shutil.rmtree(widget_path)
+        with library_lock(carto.library_path):
+            shutil.rmtree(widget_path)
+    except LockTimeout as e:
+        return {"error": str(e)}
     except Exception as e:
         return {"error": f"Failed to delete: {e}"}
 

--- a/src/cartograph/installer.py
+++ b/src/cartograph/installer.py
@@ -351,9 +351,9 @@ def delete_from_library(carto, widget_id, confirm=False):
         }
 
     widget_path = widget["path"]
-    from .safefs import library_lock, LockTimeout
+    from .safefs import widget_lock, LockTimeout
     try:
-        with library_lock(carto.library_path):
+        with widget_lock(carto.library_path, widget_id):
             shutil.rmtree(widget_path)
     except LockTimeout as e:
         return {"error": str(e)}

--- a/src/cartograph/safefs.py
+++ b/src/cartograph/safefs.py
@@ -38,29 +38,31 @@ __all__ = [
     "UnsafeArchiveError",
     "staged_dir",
     "atomic_swap_dir",
+    "widget_lock",
     "library_lock",
     "LockTimeout",
 ]
 
 LOCK_FILENAME = ".cartograph.lock"
+LOCK_DIRNAME = ".locks"
 
 
 class LockTimeout(RuntimeError):
-    """Raised when the library lock can't be acquired within the timeout."""
+    """Raised when a lock can't be acquired within the timeout."""
+
+
+def _widget_lock_id(widget_id):
+    """Filesystem-safe lock-file stem for a widget id.
+
+    Widget ids can carry ``@owner/`` and registry prefixes, so map the path
+    separators to a flat name that still collides only for the same widget.
+    """
+    return widget_id.replace("/", "__").replace("\\", "__").replace("@", "_at_")
 
 
 @contextmanager
-def library_lock(lock_dir, timeout=30.0, poll=0.1):
-    """Exclusive cross-process lock over a library directory.
-
-    Serializes library-mutating operations (checkin / sync / delete / import)
-    against other cartograph processes. Reentrant within a single thread (the
-    underlying widget keys reentrancy by lock path). Raises ``LockTimeout`` if
-    another holder keeps it past ``timeout``.
-    """
-    os.makedirs(lock_dir, exist_ok=True)
-    lock_path = os.path.join(lock_dir, LOCK_FILENAME)
-
+def _path_lock(lock_path, timeout, poll, what):
+    os.makedirs(os.path.dirname(lock_path), exist_ok=True)
     # Acquire with a timed retry, kept separate from the body so an exception
     # raised inside the locked section is never mistaken for contention.
     deadline = time.monotonic() + timeout
@@ -73,12 +75,41 @@ def library_lock(lock_dir, timeout=30.0, poll=0.1):
         except _LockBusy:
             if time.monotonic() >= deadline:
                 raise LockTimeout(
-                    f"Could not acquire the library lock within {timeout:.0f}s "
-                    f"({lock_path}). Another cartograph process may be running; "
-                    f"retry once it finishes."
+                    f"Could not acquire the {what} lock within {timeout:.0f}s "
+                    f"({lock_path}). Another cartograph process may be holding "
+                    f"it; retry once it finishes."
                 )
             time.sleep(poll)
     try:
         yield
     finally:
         cm.__exit__(None, None, None)
+
+
+def widget_lock(library_path, widget_id, timeout=30.0, poll=0.1):
+    """Exclusive cross-process lock scoped to a SINGLE widget.
+
+    This is the right granularity for checkin / sync-pull / delete / adopt:
+    two agents operating on *different* widgets run concurrently, and only
+    operations on the *same* widget serialize (so their staged swaps can't
+    interleave). The lock file lives in ``<library>/.locks/`` - a stable
+    location outside the widget directory, so it survives the atomic dir swap
+    and exists even before a brand-new widget's directory does.
+
+    Reentrant within a single thread for the same widget.
+    """
+    lock_path = os.path.join(library_path, LOCK_DIRNAME,
+                             f"{_widget_lock_id(widget_id)}.lock")
+    return _path_lock(lock_path, timeout, poll, f"widget '{widget_id}'")
+
+
+def library_lock(lock_dir, timeout=30.0, poll=0.1):
+    """Exclusive cross-process lock over the WHOLE library.
+
+    Coarse - serializes against every other library mutation regardless of
+    widget. Prefer :func:`widget_lock` for per-widget operations; reserve this
+    for the rare op that needs a library-wide barrier (e.g. a consistent
+    full-library snapshot). Reentrant within a single thread.
+    """
+    lock_path = os.path.join(lock_dir, LOCK_FILENAME)
+    return _path_lock(lock_path, timeout, poll, "library")

--- a/src/cartograph/safefs.py
+++ b/src/cartograph/safefs.py
@@ -27,12 +27,14 @@ from cg.universal_atomic_dir_swap_python.src.atomic_dir_swap import (
 from cg.universal_safe_archive_extract_python.src.safe_archive_extract import (
     safe_extractall,
     safe_extract_zip,
+    assert_members_safe,
     UnsafeArchiveError,
 )
 
 __all__ = [
     "safe_extractall",
     "safe_extract_zip",
+    "assert_members_safe",
     "UnsafeArchiveError",
     "staged_dir",
     "atomic_swap_dir",

--- a/src/cartograph/safefs.py
+++ b/src/cartograph/safefs.py
@@ -1,0 +1,82 @@
+"""Filesystem safety glue for library-mutating operations.
+
+Thin wrappers over three widgets that own the actual mechanisms:
+
+* ``cg.infra_interprocess_lock_python`` - cross-process advisory lock
+* ``cg.universal_atomic_dir_swap_python`` - crash-safe directory replace
+* ``cg.universal_safe_archive_extract_python`` - zip-slip-guarded extraction
+
+This module owns only CLI *policy*: where the library lock file lives, and the
+poll/timeout wait loop. The wait loop can't live in the lock widget - a busy
+``sleep`` is blocked in widget ``src`` by the validator - so the widget exposes
+non-blocking ``file_lock(blocking=False)`` and the timed retry lives here.
+"""
+
+import os
+import time
+from contextlib import contextmanager
+
+from cg.infra_interprocess_lock_python.src.interprocess_lock import (
+    file_lock as _file_lock,
+    LockBusy as _LockBusy,
+)
+from cg.universal_atomic_dir_swap_python.src.atomic_dir_swap import (
+    staged_dir,
+    atomic_swap_dir,
+)
+from cg.universal_safe_archive_extract_python.src.safe_archive_extract import (
+    safe_extractall,
+    safe_extract_zip,
+    UnsafeArchiveError,
+)
+
+__all__ = [
+    "safe_extractall",
+    "safe_extract_zip",
+    "UnsafeArchiveError",
+    "staged_dir",
+    "atomic_swap_dir",
+    "library_lock",
+    "LockTimeout",
+]
+
+LOCK_FILENAME = ".cartograph.lock"
+
+
+class LockTimeout(RuntimeError):
+    """Raised when the library lock can't be acquired within the timeout."""
+
+
+@contextmanager
+def library_lock(lock_dir, timeout=30.0, poll=0.1):
+    """Exclusive cross-process lock over a library directory.
+
+    Serializes library-mutating operations (checkin / sync / delete / import)
+    against other cartograph processes. Reentrant within a single thread (the
+    underlying widget keys reentrancy by lock path). Raises ``LockTimeout`` if
+    another holder keeps it past ``timeout``.
+    """
+    os.makedirs(lock_dir, exist_ok=True)
+    lock_path = os.path.join(lock_dir, LOCK_FILENAME)
+
+    # Acquire with a timed retry, kept separate from the body so an exception
+    # raised inside the locked section is never mistaken for contention.
+    deadline = time.monotonic() + timeout
+    cm = None
+    while cm is None:
+        attempt = _file_lock(lock_path, blocking=False)
+        try:
+            attempt.__enter__()
+            cm = attempt
+        except _LockBusy:
+            if time.monotonic() >= deadline:
+                raise LockTimeout(
+                    f"Could not acquire the library lock within {timeout:.0f}s "
+                    f"({lock_path}). Another cartograph process may be running; "
+                    f"retry once it finishes."
+                )
+            time.sleep(poll)
+    try:
+        yield
+    finally:
+        cm.__exit__(None, None, None)

--- a/tests/test_safefs.py
+++ b/tests/test_safefs.py
@@ -1,0 +1,117 @@
+"""Tests for the safefs glue layer.
+
+The underlying mechanisms (zip-slip guard, atomic dir swap, the lock
+primitive) are exercised in their own widget test suites under
+cg/*/tests/. Here we test the CLI glue: that the re-exports are wired, and
+that library_lock applies the poll/timeout + reentrancy policy correctly.
+"""
+
+import io
+import os
+import threading
+import time
+import zipfile
+
+import pytest
+
+from cartograph.safefs import (
+    safe_extractall,
+    staged_dir,
+    atomic_swap_dir,
+    library_lock,
+    LockTimeout,
+    UnsafeArchiveError,
+)
+
+
+# --- re-exports are wired to the widgets ----------------------------------
+
+def test_safe_extractall_reexport_blocks_traversal(tmp_path):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("../evil.py", "x")
+    buf.seek(0)
+    with zipfile.ZipFile(buf) as zf:
+        with pytest.raises(UnsafeArchiveError):
+            safe_extractall(zf, str(tmp_path / "out"))
+
+
+def test_staged_dir_reexport_swaps_in(tmp_path):
+    dest = tmp_path / "w"
+    dest.mkdir()
+    (dest / "old").write_text("old")
+    with staged_dir(str(dest)) as tmp:
+        with open(os.path.join(tmp, "new"), "w") as f:
+            f.write("new")
+    assert (dest / "new").exists() and not (dest / "old").exists()
+
+
+def test_atomic_swap_dir_reexport(tmp_path):
+    new = tmp_path / ".cg-new-x"
+    new.mkdir()
+    (new / "f").write_text("v")
+    atomic_swap_dir(str(new), str(tmp_path / "dest"))
+    assert (tmp_path / "dest" / "f").read_text() == "v"
+
+
+# --- library_lock policy --------------------------------------------------
+
+def test_library_lock_creates_lockfile_and_runs_body(tmp_path):
+    ran = []
+    with library_lock(str(tmp_path), timeout=2):
+        ran.append(True)
+        assert os.path.exists(os.path.join(str(tmp_path), ".cartograph.lock"))
+    assert ran == [True]
+
+
+def test_library_lock_reentrant_same_thread(tmp_path):
+    d = str(tmp_path)
+    with library_lock(d, timeout=2):
+        with library_lock(d, timeout=2):  # must not self-deadlock
+            pass
+
+
+def test_library_lock_serializes_threads(tmp_path):
+    d = str(tmp_path)
+    order = []
+
+    def worker(tag, hold):
+        with library_lock(d, timeout=5):
+            order.append(f"{tag}-in")
+            time.sleep(hold)
+            order.append(f"{tag}-out")
+
+    t1 = threading.Thread(target=worker, args=("a", 0.3))
+    t1.start()
+    time.sleep(0.05)
+    t2 = threading.Thread(target=worker, args=("b", 0.0))
+    t2.start()
+    t1.join()
+    t2.join()
+    assert order == ["a-in", "a-out", "b-in", "b-out"]
+
+
+def test_library_lock_times_out_when_held_by_another_process(tmp_path):
+    """A separate process holds the library lock; a short timeout must raise
+    LockTimeout instead of hanging."""
+    import subprocess
+    import sys
+    import textwrap
+
+    d = str(tmp_path)
+    holder = textwrap.dedent(f"""
+        import sys, time
+        from cartograph.safefs import library_lock
+        with library_lock({d!r}, timeout=5):
+            print("HELD", flush=True)
+            time.sleep(3)
+    """)
+    proc = subprocess.Popen([sys.executable, "-c", holder],
+                            stdout=subprocess.PIPE, text=True)
+    try:
+        assert proc.stdout.readline().strip() == "HELD"
+        with pytest.raises(LockTimeout):
+            with library_lock(d, timeout=0.5, poll=0.05):
+                pass
+    finally:
+        proc.wait(timeout=10)

--- a/tests/test_safefs.py
+++ b/tests/test_safefs.py
@@ -18,10 +18,49 @@ from cartograph.safefs import (
     safe_extractall,
     staged_dir,
     atomic_swap_dir,
+    widget_lock,
     library_lock,
     LockTimeout,
     UnsafeArchiveError,
 )
+
+
+def test_widget_lock_different_widgets_do_not_block(tmp_path):
+    """Two DIFFERENT widgets must be lockable concurrently - the whole point of
+    per-widget granularity. Acquire one and confirm the other is still free."""
+    lib = str(tmp_path)
+    with widget_lock(lib, "backend-a-python", timeout=2):
+        # A different widget's lock is independent and acquires immediately.
+        with widget_lock(lib, "backend-b-python", timeout=2):
+            pass
+
+
+def test_widget_lock_same_widget_serializes(tmp_path):
+    import threading
+    import time as _t
+    lib = str(tmp_path)
+    order = []
+
+    def worker(tag, hold):
+        with widget_lock(lib, "backend-same-python", timeout=5):
+            order.append(f"{tag}-in")
+            _t.sleep(hold)
+            order.append(f"{tag}-out")
+
+    t1 = threading.Thread(target=worker, args=("a", 0.3))
+    t1.start()
+    _t.sleep(0.05)
+    t2 = threading.Thread(target=worker, args=("b", 0.0))
+    t2.start()
+    t1.join()
+    t2.join()
+    assert order == ["a-in", "a-out", "b-in", "b-out"]
+
+
+def test_widget_lock_id_with_path_chars(tmp_path):
+    """A cloud-style id with @ and / must produce a usable lock file."""
+    with widget_lock(str(tmp_path), "@owner/cg-backend-x-python", timeout=2):
+        pass
 
 
 # --- re-exports are wired to the widgets ----------------------------------

--- a/tests/test_safety_commands.py
+++ b/tests/test_safety_commands.py
@@ -1,0 +1,89 @@
+"""Regression tests for safety wiring on library-mutating commands.
+
+These exercise the failure modes the safety audit flagged: zip-slip on
+extraction, and tearing down the live library copy before the replacement is
+ready. They target the seams (safefs primitives as used by sync/import) rather
+than driving the full CLI, which needs cloud/registry plumbing.
+"""
+
+import io
+import os
+import zipfile
+from io import BytesIO
+
+import pytest
+
+from cartograph.safefs import (
+    safe_extractall,
+    staged_dir,
+    assert_members_safe,
+    UnsafeArchiveError,
+)
+
+
+def _zip(members):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, content in members.items():
+            zf.writestr(name, content)
+    buf.seek(0)
+    return buf
+
+
+# --- import: zip-slip guard on the member list -----------------------------
+
+def test_import_member_guard_rejects_traversal(tmp_path):
+    """The guard `import` runs up front rejects a library-escaping member."""
+    names = ["widget-a/widget.json", "../../evil.py", "widget-a/src/m.py"]
+    with pytest.raises(UnsafeArchiveError):
+        assert_members_safe(names, str(tmp_path / "library"))
+
+
+def test_import_member_guard_passes_normal_layout(tmp_path):
+    names = ["w/widget.json", "w/src/m.py", "w/tests/t.py", "w/"]
+    assert_members_safe(names, str(tmp_path / "library"))
+
+
+# --- sync pull: staged safe extract --------------------------------------
+
+def test_sync_pull_rejects_zip_slip_and_keeps_old_copy(tmp_path):
+    """Modelled on the sync-pull path: extract registry bytes into a staged dir
+    then atomic-swap. A zip-slip member must abort with the OLD library copy
+    still intact - never the rmtree-first-then-fail behavior."""
+    dest = tmp_path / "library" / "backend-evil-python"
+    dest.mkdir(parents=True)
+    (dest / "widget.json").write_text('{"old": true}')
+
+    evil_bytes = _zip({"../../escaped.py": "pwned", "src/m.py": "x"}).getvalue()
+
+    with pytest.raises(UnsafeArchiveError):
+        with staged_dir(str(dest)) as staging:
+            with zipfile.ZipFile(BytesIO(evil_bytes)) as zf:
+                safe_extractall(zf, staging)
+
+    # Old copy untouched; nothing escaped the library dir.
+    assert (dest / "widget.json").read_text() == '{"old": true}'
+    assert not (tmp_path / "escaped.py").exists()
+    assert not any(p.name.startswith(".cg-new-")
+                   for p in (tmp_path / "library").iterdir())
+
+
+def test_sync_pull_swaps_in_clean_archive(tmp_path):
+    """A well-formed pull fully replaces the old library copy atomically."""
+    dest = tmp_path / "library" / "backend-ok-python"
+    dest.mkdir(parents=True)
+    (dest / "widget.json").write_text('{"version": "1.0.0"}')
+    (dest / "stale.txt").write_text("remove me")
+
+    good = _zip({
+        "widget.json": '{"version": "2.0.0"}',
+        "src/m.py": "def f(): pass",
+    }).getvalue()
+
+    with staged_dir(str(dest)) as staging:
+        with zipfile.ZipFile(BytesIO(good)) as zf:
+            safe_extractall(zf, staging)
+
+    assert (dest / "widget.json").read_text() == '{"version": "2.0.0"}'
+    assert (dest / "src" / "m.py").exists()
+    assert not (dest / "stale.txt").exists()  # fully replaced, not merged


### PR DESCRIPTION
Hardens every library-mutating command against the failure classes a robustness audit surfaced: non-atomic in-place rewrites, missing concurrency control, and zip-slip on untrusted archives.

## Three new stdlib-only widgets (zero deps preserved)
- **infra-interprocess-lock-python** — cross-process advisory lock (fcntl/msvcrt), blocking + non-blocking, per-thread reentrant.
- **universal-atomic-dir-swap-python** — build replacement in a sibling temp dir, swap in via rename; live copy never torn down before its replacement is ready.
- **universal-safe-archive-extract-python** (1.1.0) — validates zip members before extractall; `assert_members_safe` for selective extraction.

`safefs.py` is thin glue over these (the lock's poll/timeout policy lives here, since a sleep loop can't live in a widget per the validator).

## Commands hardened
- **checkin** — locked + staged atomic library write; source-manifest bump reordered to *after* the swap (fixes the desync wedge); corrupt changelog preserved, not silently dropped.
- **cloud sync (pull)** — `safe_extractall` into a staged dir + atomic swap under the lock (was `rmtree(dest)` then `extractall` with no zip-slip guard — destroyed the live copy on a failed/malicious pull).
- **import** — zip-slip guard up front + whole extract/integrity-gate under the lock.
- **install (_install_from_cloud)** — `safe_extractall` instead of bare `extractall`.
- **delete / cloud adopt** — serialized under the library lock.

## Tests
- Per-widget suites (lock contention/reentrancy/timeout, atomic-swap rollback, zip-slip rejection).
- `test_safefs.py` (glue) + `test_safety_commands.py` (sync/import zip-slip rejection, old-copy-intact on bad pull).
- **Full suite: 801 passed.**

## Release coordination
Bumped to **0.7.13** assuming PR #23 (0.7.12) merges first. If merge order differs, the version needs adjusting before merge. PR #24 (loud auto-tag) is independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)