### PR TITLE
fix(rust): coverage 0% on real widgets + dep widgets failing validate

### DIFF
--- a/src/cartograph/languages/rust.py
+++ b/src/cartograph/languages/rust.py
@@ -232,7 +232,16 @@ class RustEngine(LanguageEngine):
                                 cwd=path, timeout=300, env=self._cargo_env())
                 if res.returncode != 0:
                     output = (res.stderr or res.stdout or "").strip()
-                    errors.append(f"cargo build failed:\n{output[:3000]}")
+                    # validate_widget runs BEFORE install_deps in the validator
+                    # pipeline, so a declared-but-not-yet-added crate is expected
+                    # here (cargo emits E0432/E0433 "unresolved import/module or
+                    # unlinked crate"). Defer to run_tests, which builds again
+                    # after install_deps. Mirrors Go's missing-module skip.
+                    deferred = bool(dependencies) and (
+                        "unresolved module or unlinked crate" in output
+                        or "unresolved import" in output)
+                    if not deferred:
+                        errors.append(f"cargo build failed:\n{output[:3000]}")
             except FileNotFoundError:
                 errors.append("cargo not found - install the Rust toolchain "
                               "(rustup.rs).")
@@ -333,12 +342,12 @@ class RustEngine(LanguageEngine):
         # --summary-only --json gives a machine-readable total; the
         # ignore-filename-regex keeps the denominator to src/ (tests/ and
         # examples/ code must not pad the coverage number).
+        #
+        ignore = self._coverage_ignore_regex(path)
         try:
             res = self._run(
                 ["cargo", "llvm-cov", "--summary-only", "--json",
-                 # tests/ and examples/ never pad the denominator; cg/ excludes
-                 # composed dep widgets when this runs over a blueprint sandbox.
-                 "--ignore-filename-regex", r"(tests|examples|cg)[/\\]"],
+                 "--ignore-filename-regex", ignore],
                 cwd=path, timeout=600, env=self._cargo_env(),
             )
         except FileNotFoundError:
@@ -365,6 +374,22 @@ class RustEngine(LanguageEngine):
                 f"{_COVERAGE_THRESHOLD}% - add tests for the uncovered lines "
                 f"(cargo llvm-cov --summary-only shows per-file gaps)")
         return self._ok()
+
+    @staticmethod
+    def _coverage_ignore_regex(path):
+        """The --ignore-filename-regex for cargo-llvm-cov.
+
+        Always excludes tests/ and examples/ from the coverage denominator.
+        Only excludes cg/ for a BLUEPRINT sandbox, where composed dependency
+        widgets live under cg/ and must not count toward the blueprint's own
+        coverage. A normal widget is itself installed at cg/<id>/src/lib.rs, so
+        excluding cg/ there would match the widget's OWN source via its install
+        path and report a false 0%. A blueprint is detected by its manifest,
+        not its path.
+        """
+        if os.path.isfile(os.path.join(path, "blueprint.json")):
+            return r"(tests|examples|cg)[/\\]"
+        return r"(tests|examples)[/\\]"
 
     @staticmethod
     def _parse_coverage(stdout):

--- a/tests/test_rust_engine.py
+++ b/tests/test_rust_engine.py
@@ -1,0 +1,39 @@
+"""Rust engine unit tests that don't need the cargo toolchain.
+
+These guard logic that has bitten us before, so they run in CI on every
+platform regardless of whether Rust is installed.
+"""
+
+import os
+
+from cartograph.languages.rust import RustEngine
+
+
+def test_coverage_ignore_regex_excludes_only_tests_examples_for_a_widget(tmp_path):
+    """Regression: a normal widget installs at cg/<id>/src/lib.rs, so excluding
+    'cg' from the coverage denominator matched the widget's OWN source via its
+    install path and reported a false 0% coverage. A non-blueprint path must
+    exclude only tests/ and examples/ - never cg/."""
+    widget = tmp_path / "cg" / "universal-thing-rust"
+    (widget / "src").mkdir(parents=True)
+    regex = RustEngine._coverage_ignore_regex(str(widget))
+    assert "cg" not in regex
+    assert regex == r"(tests|examples)[/\\]"
+
+
+def test_coverage_ignore_regex_excludes_cg_for_a_blueprint(tmp_path):
+    """A blueprint sandbox carries dep widgets under cg/ that must not count
+    toward the blueprint's own coverage. Detected by blueprint.json, not path."""
+    bp = tmp_path / "bp-thing-rust"
+    bp.mkdir()
+    (bp / "blueprint.json").write_text("{}")
+    regex = RustEngine._coverage_ignore_regex(str(bp))
+    assert regex == r"(tests|examples|cg)[/\\]"
+
+
+def test_parse_coverage_reads_llvm_cov_json():
+    """The total line percent comes from data[0].totals.lines.percent."""
+    payload = '{"data":[{"totals":{"lines":{"percent":87.5}}}]}'
+    assert RustEngine._parse_coverage(payload) == 87.5
+    assert RustEngine._parse_coverage("") is None
+    assert RustEngine._parse_coverage("not json") is None


### PR DESCRIPTION
Two Rust-engine bugs found by validating **real** widgets (not just scaffolds) - both would have broken the engine the moment it flips to `supported=True`, so worth fixing while it's still dormant.

## 1. Coverage falsely reported 0% on every real widget
`run_tests` excluded `cg` from the cargo-llvm-cov denominator to drop blueprint dependency widgets. But a normal widget is installed at `cg/<id>/src/lib.rs`, so the exclusion matched the **widget's own source** via its install path → `count: 0` → false "Coverage 0.0% is below 80%" rejection. The scaffold tests passed only because they scaffolded to paths without `cg/`.

**Fix:** only blueprint sandboxes (detected by `blueprint.json`, not the path) exclude `cg/`; a normal widget excludes only `tests/` and `examples/`. Extracted to `_coverage_ignore_regex` with a unit-test guard that runs on every platform (no cargo needed).

## 2. Dependency widgets failed validate
`validate_widget` runs **before** `install_deps` in the validator pipeline (validator.py: build at line 238, install at 248), so `cargo build --lib` hit an unresolved declared crate and hard-failed. Now it defers `E0432`/`E0433` unresolved-crate errors to `run_tests` (which builds after `install_deps`), mirroring Go's existing missing-module skip.

## Verification
Built five real widgets across Rust's risk surface and validated each end-to-end through the CLI: a generic ring buffer, a `Result`/error-enum parser, a trait-based backoff, a **multi-module** crate (`lib.rs` + submodule, exercising multi-file coverage), and one with a real **`hex`** dependency. All five fail before this change (four at "0%", the dep one at "unresolved crate") and pass after.

Added `tests/test_rust_engine.py` (toolchain-free) guarding the ignore-regex logic and the coverage JSON parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)