### PR TITLE
blueprint add-dep/remove-dep: wire compiled-language manifests

### DIFF
--- a/src/cartograph/blueprint_deps.py
+++ b/src/cartograph/blueprint_deps.py
@@ -19,8 +19,29 @@ import os
 
 from .engine import DEFAULT_INSTALL_DIR, find_installed_widget_dir
 from .blueprints import is_blueprint_id, parse_blueprint_id
+from .languages import get_engine
 
 log = logging.getLogger("cartograph")
+
+
+def _snapshot_manifests(engine, blueprint_path: str) -> dict:
+    """Capture the current contents of the engine's manifest files so a failed
+    validation can restore them (None marks a file that did not exist)."""
+    snap = {}
+    for name in getattr(engine, "manifest_patterns", []) or []:
+        p = os.path.join(blueprint_path, name)
+        snap[p] = open(p, encoding="utf-8").read() if os.path.isfile(p) else None
+    return snap
+
+
+def _restore_manifests(snap: dict) -> None:
+    for p, content in snap.items():
+        if content is None:
+            if os.path.isfile(p):
+                os.remove(p)
+        else:
+            with open(p, "w", newline="\n", encoding="utf-8") as f:
+                f.write(content)
 
 
 def _load_blueprint(blueprint_path: str) -> tuple[dict | None, dict | None]:
@@ -170,8 +191,26 @@ def add_dep(carto, blueprint_path: str, widget_id: str, validate: bool = True) -
     data["dependencies"] = deps
     _write_manifest(blueprint_path, data)
 
+    # Wire the composed widget into the blueprint's language manifest (Cargo
+    # path dep, go.mod require+replace, ...) so it compiles against the dep
+    # without the author hand-editing. No-op for interpreted languages.
+    engine = get_engine(bid.language)
+    manifest_snap = _snapshot_manifests(engine, blueprint_path) if engine else {}
+    if engine:
+        cg_root = os.path.join(project_root, DEFAULT_INSTALL_DIR)
+        dep_dir = find_installed_widget_dir(cg_root, widget_id)
+        try:
+            engine.wire_blueprint_dep(blueprint_path, widget_id, dep_dir)
+        except Exception as e:
+            _write_manifest(blueprint_path, before)
+            _restore_manifests(manifest_snap)
+            return {"status": "error",
+                    "message": f"Failed to wire {widget_id} into the "
+                               f"blueprint manifest: {e}"}
+
     failure = _maybe_validate(carto, blueprint_path, before, validate)
     if failure:
+        _restore_manifests(manifest_snap)
         return failure
 
     log.info("blueprint %s: added dep %s@%s", bp_id, widget_id, pinned)
@@ -212,8 +251,24 @@ def remove_dep(carto, blueprint_path: str, widget_id: str, validate: bool = True
     data["dependencies"] = new_deps
     _write_manifest(blueprint_path, data)
 
+    # Unwire the composed widget from the blueprint's language manifest. No-op
+    # for interpreted languages. bid from parse_blueprint_id above.
+    bid = parse_blueprint_id(bp_id)
+    engine = get_engine(bid.language)
+    manifest_snap = _snapshot_manifests(engine, blueprint_path) if engine else {}
+    if engine:
+        try:
+            engine.unwire_blueprint_dep(blueprint_path, widget_id)
+        except Exception as e:
+            _write_manifest(blueprint_path, before)
+            _restore_manifests(manifest_snap)
+            return {"status": "error",
+                    "message": f"Failed to unwire {widget_id} from the "
+                               f"blueprint manifest: {e}"}
+
     failure = _maybe_validate(carto, blueprint_path, before, validate)
     if failure:
+        _restore_manifests(manifest_snap)
         return failure
 
     log.info("blueprint %s: removed dep %s", bp_id, widget_id)

--- a/src/cartograph/languages/base.py
+++ b/src/cartograph/languages/base.py
@@ -535,6 +535,29 @@ class LanguageEngine:
                     "error": (res.stderr or res.stdout or "").strip()}
         return {"passed": True}
 
+    def wire_blueprint_dep(self, blueprint_dir: str, dep_id: str,
+                           dep_dir: str) -> None:
+        """Wire a composed widget into the blueprint's language manifest.
+
+        Called by `blueprint add-dep` after the dep is pinned in
+        blueprint.json. Compiled languages that resolve deps through a
+        manifest (Rust's Cargo.toml, Go's go.mod) override this to add a
+        path/replace entry pointing at `cg/<dep_id>/` - the layout the
+        validator sandbox populates - so the blueprint compiles against
+        the composed widget without the author hand-editing the manifest.
+
+        Base is a no-op: interpreted languages resolve composed widgets via
+        the sandbox's cg/ copy plus relative references in source (Python's
+        PYTHONPATH, JS/PHP relative requires, Nim's --path:), so there is no
+        separate manifest to touch. Must be idempotent.
+        """
+        return
+
+    def unwire_blueprint_dep(self, blueprint_dir: str, dep_id: str) -> None:
+        """Remove a composed widget's entry from the blueprint's language
+        manifest. The inverse of wire_blueprint_dep; base is a no-op."""
+        return
+
     def required_files(self, path: str) -> list[tuple[str, str]]:
         """Return [(relative_path, error_hint)] for files that must exist before tests run."""
         return []

--- a/src/cartograph/languages/go.py
+++ b/src/cartograph/languages/go.py
@@ -412,6 +412,71 @@ class GoEngine(LanguageEngine):
                     "error": (res.stderr or res.stdout or "").strip()}
         return {"passed": True}
 
+    # ---- blueprint dep wiring ----------------------------------------------
+
+    def wire_blueprint_dep(self, blueprint_dir, dep_id, dep_dir):
+        """Wire a composed widget into go.mod via Go's local-module mechanism:
+        a `require <module> v0.0.0` plus a `replace <module> => ./cg/<dep_id>`
+        pointing at the layout the validator sandbox populates. Idempotent."""
+        manifest = os.path.join(blueprint_dir, "go.mod")
+        if not os.path.isfile(manifest):
+            return
+        rel = f"./cg/{dep_id}"
+        with open(manifest, encoding="utf-8") as f:
+            text = f.read()
+        if f"=> {rel}" in text:
+            return
+        module = self._go_module_name(dep_dir)
+        if not module:
+            return
+        block = f"\nrequire {module} v0.0.0\n\nreplace {module} => {rel}\n"
+        text = text.rstrip("\n") + "\n" + block
+        with open(manifest, "w", newline="\n", encoding="utf-8") as f:
+            f.write(text)
+
+    def unwire_blueprint_dep(self, blueprint_dir, dep_id):
+        """Drop the require/replace pair that composes the given widget."""
+        manifest = os.path.join(blueprint_dir, "go.mod")
+        if not os.path.isfile(manifest):
+            return
+        rel = f"./cg/{dep_id}"
+        with open(manifest, encoding="utf-8") as f:
+            lines = f.readlines()
+        module = None
+        for ln in lines:
+            parts = ln.split()
+            if (len(parts) >= 4 and parts[0] == "replace"
+                    and parts[2] == "=>" and parts[3] == rel):
+                module = parts[1]
+                break
+        if module is None:
+            return
+        kept = []
+        for ln in lines:
+            parts = ln.split()
+            if (len(parts) >= 4 and parts[0] == "replace"
+                    and parts[2] == "=>" and parts[3] == rel):
+                continue
+            if (len(parts) >= 2 and parts[0] == "require"
+                    and parts[1] == module):
+                continue
+            kept.append(ln)
+        with open(manifest, "w", newline="\n", encoding="utf-8") as f:
+            f.writelines(kept)
+
+    @staticmethod
+    def _go_module_name(widget_dir):
+        """Read the module path from a widget's go.mod, or None."""
+        manifest = os.path.join(widget_dir, "go.mod")
+        if not os.path.isfile(manifest):
+            return None
+        with open(manifest, encoding="utf-8") as f:
+            for raw in f:
+                parts = raw.split()
+                if len(parts) >= 2 and parts[0] == "module":
+                    return parts[1]
+        return None
+
     # ---- cleanup -----------------------------------------------------------
 
     def cleanup(self, path: str) -> None:

--- a/src/cartograph/languages/rust.py
+++ b/src/cartograph/languages/rust.py
@@ -97,6 +97,19 @@ def _rust_crate_name(module_name: str) -> str:
     return module_name.replace("-", "_")
 
 
+def _insert_under_section(text: str, header: str, line: str) -> str:
+    """Insert `line` immediately after the `[section]` header in a TOML-ish
+    manifest, creating the section at the end if it is absent. Stdlib-only
+    (no toml dep) - the manifest is a flat Cargo.toml the scaffold controls."""
+    lines = text.splitlines(keepends=True)
+    for i, raw in enumerate(lines):
+        if raw.strip() == header:
+            lines.insert(i + 1, line)
+            return "".join(lines)
+    tail = "" if text.endswith("\n") or not text else "\n"
+    return text + tail + f"\n{header}\n{line}"
+
+
 class RustEngine(LanguageEngine):
     name = "rust"
     validation_version = 1
@@ -451,6 +464,59 @@ class RustEngine(LanguageEngine):
             return {"passed": False,
                     "error": (res.stderr or res.stdout or "").strip()}
         return {"passed": True}
+
+    # ---- blueprint dep wiring ----------------------------------------------
+
+    def wire_blueprint_dep(self, blueprint_dir, dep_id, dep_dir):
+        """Add a Cargo path dependency on the composed widget so the blueprint
+        compiles against it. Points at `cg/<dep_id>/`, the layout the validator
+        sandbox populates. Idempotent - re-adding an existing dep is a no-op."""
+        manifest = os.path.join(blueprint_dir, "Cargo.toml")
+        if not os.path.isfile(manifest):
+            return
+        rel = f"cg/{dep_id}"
+        with open(manifest, encoding="utf-8") as f:
+            text = f.read()
+        if f'path = "{rel}"' in text:
+            return
+        crate = self._cargo_package_name(dep_dir) or _rust_crate_name(dep_id)
+        line = f'{crate} = {{ path = "{rel}" }}\n'
+        text = _insert_under_section(text, "[dependencies]", line)
+        with open(manifest, "w", encoding="utf-8", newline="\n") as f:
+            f.write(text)
+
+    def unwire_blueprint_dep(self, blueprint_dir, dep_id):
+        """Drop the Cargo path dependency on the composed widget."""
+        manifest = os.path.join(blueprint_dir, "Cargo.toml")
+        if not os.path.isfile(manifest):
+            return
+        rel = f'path = "cg/{dep_id}"'
+        with open(manifest, encoding="utf-8") as f:
+            lines = f.readlines()
+        kept = [ln for ln in lines if rel not in ln]
+        if len(kept) != len(lines):
+            with open(manifest, "w", encoding="utf-8", newline="\n") as f:
+                f.writelines(kept)
+
+    @staticmethod
+    def _cargo_package_name(widget_dir):
+        """Read the [package] name from a widget's Cargo.toml, or None."""
+        manifest = os.path.join(widget_dir, "Cargo.toml")
+        if not os.path.isfile(manifest):
+            return None
+        import re
+        section = None
+        with open(manifest, encoding="utf-8") as f:
+            for raw in f:
+                line = raw.strip()
+                if line.startswith("[") and line.endswith("]"):
+                    section = line
+                    continue
+                if section == "[package]":
+                    m = re.match(r'name\s*=\s*"([^"]+)"', line)
+                    if m:
+                        return m.group(1)
+        return None
 
     # ---- cleanup -----------------------------------------------------------
 

--- a/tests/test_blueprint_deps.py
+++ b/tests/test_blueprint_deps.py
@@ -211,3 +211,142 @@ def test_add_dep_reverts_manifest_when_validation_fails(carto, project, tmp_path
     # Manifest restored.
     bp_manifest_after = json.load(open(os.path.join(bp, "blueprint.json")))
     assert bp_manifest_after == bp_manifest_before
+
+
+# --- language manifest wiring (compiled engines) -----------------------------
+#
+# add-dep / remove-dep also wire the dep into the blueprint's language manifest
+# so it compiles against the composed widget without hand-editing. These run
+# with validate=False, so they exercise the file-editing hooks directly and
+# need no cargo/go toolchain.
+
+def _write_installed_rust_widget(project_dir, widget_id, crate, version="1.0.0"):
+    """Rust install dir stays hyphenated (cargo keys off Cargo.toml, not the
+    dir name); the crate name is the [package] name."""
+    wdir = os.path.join(project_dir, "cg", widget_id)
+    os.makedirs(os.path.join(wdir, "src"))
+    domain = widget_id.split("-")[0]
+    manifest = {
+        "meta": {"id": widget_id, "name": crate, "version": version,
+                 "domain": domain, "tags": ["a", "b", "c"]},
+        "tech_stack": {"language": "rust", "dependencies": []},
+        "description": "fake widget",
+    }
+    with open(os.path.join(wdir, "widget.json"), "w") as f:
+        json.dump(manifest, f, indent=2)
+    with open(os.path.join(wdir, "Cargo.toml"), "w") as f:
+        f.write(f'[package]\nname = "{crate}"\nversion = "0.1.0"\n'
+                'edition = "2021"\n\n[dependencies]\n')
+    return wdir
+
+
+def _write_rust_blueprint(project_dir, name="recent-cache", deps=None):
+    deps = deps or []
+    bp_id = f"bp-{name}-rust"
+    bp = os.path.join(project_dir, "cg", bp_id)
+    for sub in ("src", "tests", "examples"):
+        os.makedirs(os.path.join(bp, sub))
+    manifest = {
+        "id": bp_id, "name": name, "language": "rust", "version": "0.1.0",
+        "description": "real description", "tags": ["a", "b", "c"],
+        "dependencies": deps, "domains": [],
+    }
+    with open(os.path.join(bp, "blueprint.json"), "w") as f:
+        json.dump(manifest, f, indent=2)
+    with open(os.path.join(bp, "Cargo.toml"), "w") as f:
+        f.write('[package]\nname = "recent_cache"\nversion = "0.1.0"\n'
+                'edition = "2021"\n\n[dependencies]\n')
+    return bp
+
+
+def test_add_dep_wires_rust_cargo_path_dep(carto, project):
+    _write_installed_rust_widget(str(project), "universal-ring-buffer-rust",
+                                 crate="ring_buffer")
+    bp = _write_rust_blueprint(str(project))
+    res = carto.blueprint_add_dep(blueprint_path=bp,
+                                  widget_id="universal-ring-buffer-rust",
+                                  validate=False)
+    assert res["status"] == "success"
+    cargo = open(os.path.join(bp, "Cargo.toml")).read()
+    assert 'ring_buffer = { path = "cg/universal-ring-buffer-rust" }' in cargo
+
+
+def test_remove_dep_unwires_rust_cargo_path_dep(carto, project):
+    _write_installed_rust_widget(str(project), "universal-ring-buffer-rust",
+                                 crate="ring_buffer")
+    bp = _write_rust_blueprint(
+        str(project),
+        deps=[{"id": "universal-ring-buffer-rust", "version": "1.0.0"}])
+    # Pre-wire the manifest as add-dep would have.
+    with open(os.path.join(bp, "Cargo.toml"), "a") as f:
+        f.write('ring_buffer = { path = "cg/universal-ring-buffer-rust" }\n')
+    res = carto.blueprint_remove_dep(blueprint_path=bp,
+                                     widget_id="universal-ring-buffer-rust",
+                                     validate=False)
+    assert res["status"] == "success"
+    cargo = open(os.path.join(bp, "Cargo.toml")).read()
+    assert "ring_buffer" not in cargo
+    assert "cg/universal-ring-buffer-rust" not in cargo
+
+
+def _write_installed_go_widget(project_dir, widget_id, module, version="1.0.0"):
+    wdir = os.path.join(project_dir, "cg", widget_id)
+    os.makedirs(os.path.join(wdir, "src"))
+    domain = widget_id.split("-")[0]
+    manifest = {
+        "meta": {"id": widget_id, "name": module, "version": version,
+                 "domain": domain, "tags": ["a", "b", "c"]},
+        "tech_stack": {"language": "go", "dependencies": []},
+        "description": "fake widget",
+    }
+    with open(os.path.join(wdir, "widget.json"), "w") as f:
+        json.dump(manifest, f, indent=2)
+    with open(os.path.join(wdir, "go.mod"), "w") as f:
+        f.write(f"module {module}\n\ngo 1.24\n")
+    return wdir
+
+
+def _write_go_blueprint(project_dir, name="shouter-flow", deps=None):
+    deps = deps or []
+    bp_id = f"bp-{name}-go"
+    bp = os.path.join(project_dir, "cg", bp_id)
+    for sub in ("src", "tests", "examples"):
+        os.makedirs(os.path.join(bp, sub))
+    manifest = {
+        "id": bp_id, "name": name, "language": "go", "version": "0.1.0",
+        "description": "real description", "tags": ["a", "b", "c"],
+        "dependencies": deps, "domains": [],
+    }
+    with open(os.path.join(bp, "blueprint.json"), "w") as f:
+        json.dump(manifest, f, indent=2)
+    with open(os.path.join(bp, "go.mod"), "w") as f:
+        f.write("module shouter\n\ngo 1.24\n")
+    return bp
+
+
+def test_add_dep_wires_go_mod_require_replace(carto, project):
+    _write_installed_go_widget(str(project), "infra-greet-go", module="greet")
+    bp = _write_go_blueprint(str(project))
+    res = carto.blueprint_add_dep(blueprint_path=bp,
+                                  widget_id="infra-greet-go",
+                                  validate=False)
+    assert res["status"] == "success"
+    gomod = open(os.path.join(bp, "go.mod")).read()
+    assert "require greet v0.0.0" in gomod
+    assert "replace greet => ./cg/infra-greet-go" in gomod
+
+
+def test_remove_dep_unwires_go_mod(carto, project):
+    _write_installed_go_widget(str(project), "infra-greet-go", module="greet")
+    bp = _write_go_blueprint(
+        str(project),
+        deps=[{"id": "infra-greet-go", "version": "1.0.0"}])
+    with open(os.path.join(bp, "go.mod"), "a") as f:
+        f.write("\nrequire greet v0.0.0\n\nreplace greet => ./cg/infra-greet-go\n")
+    res = carto.blueprint_remove_dep(blueprint_path=bp,
+                                     widget_id="infra-greet-go",
+                                     validate=False)
+    assert res["status"] == "success"
+    gomod = open(os.path.join(bp, "go.mod")).read()
+    assert "greet" not in gomod
+    assert "./cg/infra-greet-go" not in gomod


### PR DESCRIPTION
## Problem
`blueprint add-dep` pinned the dep in `blueprint.json` but never touched the language's dependency manifest. For interpreted languages that's fine (the validator sandbox copies deps under `cg/` and source resolves them relatively). But for **compiled** languages the blueprint wouldn't compile against the composed widget until the author hand-edited the manifest — a Cargo `path` dep for Rust, a `require`+`replace` for Go. That step was undocumented and easy to miss (surfaced while stress-testing the Rust engine).

## Fix
A new engine hook the dep editor calls:
- `LanguageEngine.wire_blueprint_dep` / `unwire_blueprint_dep` — **base no-ops** (interpreted languages need nothing).
- **Rust** — adds `<crate> = { path = "cg/<dep-id>" }` under `[dependencies]`; crate name read from the dep's `Cargo.toml` `[package]` name. Idempotent; removed on unwire.
- **Go** — adds `require <module> v0.0.0` + `replace <module> => ./cg/<dep-id>`; module read from the dep's `go.mod`. Pair removed on unwire.

Both point at `cg/<dep-id>/`, the layout the blueprint validator sandbox populates — the same wiring the existing hand-written blueprint-language tests already encode. `add-dep`/`remove-dep` snapshot the manifest files and restore them (alongside `blueprint.json`) if post-edit validation fails, so a failed edit never leaves a half-wired manifest.

Stdlib-only line editing — no toml/go.mod parser dependency, consistent with the zero-dep policy.

## Verification
- New tests: add-dep wires / remove-dep unwires both `Cargo.toml` and `go.mod` (`validate=False`, so no cargo/go toolchain needed on CI).
- Manually confirmed end-to-end: a Rust blueprint composing two widgets now validates green straight after `add-dep`, with **no** hand-editing of `Cargo.toml`.
- `test_blueprint_deps.py` + `test_blueprint_languages.py` green (25 passed, 2 toolchain-gated skips).

Independent of the engine-flip PR (#31) — the hooks work regardless of the `supported` flag. No version bump; can ride the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)