### PR TITLE
Fix publish chain skipping fresh-install + GitHub release on auto-tag path

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,11 +54,19 @@ jobs:
   fresh-install:
     name: Fresh install
     needs: publish
+    # Explicit condition: the default success() looks at the TRANSITIVE needs
+    # chain, and `tests` is skipped on the auto-tag (workflow_dispatch) path -
+    # which silently skipped this job and `release` on every dispatched
+    # release (v0.7.12-v0.7.14 shipped with no fresh-install check and no
+    # GitHub release). Gate only on what we actually need: publish succeeded.
+    if: ${{ !cancelled() && needs.publish.result == 'success' }}
     uses: ./.github/workflows/fresh-install.yml
 
   release:
     name: Create GitHub release
     needs: fresh-install
+    # Same transitive-skip trap as fresh-install above.
+    if: ${{ !cancelled() && needs.fresh-install.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,3 +143,19 @@ Only project specific wiring should not be made into widgets.
 6. Validate before checking in, check in before publishing
 
 Definition of reusable code: Any code that would be written for another project. A lot of code may look "project specific" but if you peel back the logic you will realize it can be used across many projects. These are the widgets that need to be extracted, or made.
+
+### Pre-flight checklist (before merging engine/release PRs)
+
+1. Full local test suite green (`pytest`), including the language's
+   create / contamination / blueprint suites.
+2. Real-widget stress: at least one widget validated end-to-end via the
+   actual CLI (`cartograph create` -> `validate`), not engine methods.
+3. If remote validation nodes are configured on this machine (see the
+   workspace-level CLAUDE.md and `scripts/remote-stress-*`), run the
+   ephemeral cross-platform stress on each node and require PASS.
+4. Wait for PR CI green on all 9 matrix combos before merging. Never tag
+   or bump ahead of CI.
+5. After merge, verify the release actually shipped by checking master:
+   pyproject version bumped, the change present on origin/master, and the
+   vX.Y.Z tag created (auto-tag silently skips when the version wasn't
+   bumped - a merged PR is not proof).


### PR DESCRIPTION
Every release since the hands-off auto-tag chain went live (v0.7.12-v0.7.14) published to PyPI but silently skipped fresh-install verification and the GitHub release page.

Cause: auto-tag dispatches publish.yml via workflow_dispatch, where `tests` intentionally skips. GitHub's default `success()` condition evaluates the **transitive** needs chain, so the skip propagated through `publish` (guarded with `always()`) into `fresh-install` and `release`, which had bare `needs:`.

Fix: explicit `!cancelled() && needs.<direct-dep>.result == 'success'` conditions on both jobs, mirroring the guard `publish` already had.

Also adds a pre-flight checklist section to CLAUDE.md.

Merge this BEFORE #34 so v0.7.15 ships through the fully working chain. The three missing releases will be backfilled manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4Y61587L5cXmAZuEVWSFS