### PR TITLE
doctor: stop npx downloading playwright during the optional-tool check

### DIFF
--- a/src/cartograph/languages/javascript.py
+++ b/src/cartograph/languages/javascript.py
@@ -188,7 +188,11 @@ class JavaScriptEngine(LanguageEngine):
         checks = []
         try:
             # Through self._run so paths.npx (if configured) is honored.
-            r = self._run(["npx", "playwright", "--version"],
+            # --no-install: without it, npx DOWNLOADS playwright from the
+            # registry just to answer --version when it isn't installed -
+            # doctor hung for 30s+ on Windows and polluted the npm cache.
+            # A status probe must never mutate the machine.
+            r = self._run(["npx", "--no-install", "playwright", "--version"],
                           cwd=os.getcwd(), timeout=15)
             installed = r.returncode == 0
         except Exception:


### PR DESCRIPTION
`cartograph doctor` ran `npx playwright --version` in the JavaScript engine's `check_optional`. When playwright isn't installed, npx downloads it from the registry just to answer the version query - on Windows this hung doctor for 30+ seconds (terminal title flips to "npm exec playwright") and pollutes the npm cache. A read-only status probe shouldn't install anything.

Fix: `npx --no-install playwright --version` - instant answer from what's present, fast failure when absent, reported as "not installed" exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4Y61587L5cXmAZuEVWSFS