### PR TITLE
setup: MCP mode - trimmed agent instructions when the Cartograph MCP is connected

### DIFF
--- a/src/cartograph/cli.py
+++ b/src/cartograph/cli.py
@@ -2331,7 +2331,8 @@ def cmd_doctor(args):
         sys.exit(1)
 
 
-def _build_setup_instructions() -> str:
+def _domain_lines() -> str:
+    """Render the indented domain table from library_config.json."""
     import json as _json
     _cfg_path = os.path.join(os.path.dirname(__file__), "library_config.json")
     try:
@@ -2340,10 +2341,14 @@ def _build_setup_instructions() -> str:
     except Exception:
         cfg = {}
     domains = cfg.get("domains", {})
-    domain_lines = "\n".join(
+    return "\n".join(
         f"    {name:<10} {desc.split('.')[0].strip()}"
         for name, desc in domains.items()
     )
+
+
+def _build_setup_instructions() -> str:
+    domain_lines = _domain_lines()
 
     from .config import _SCHEMA, _DEFAULTS
     _flat_defaults = {k: v for section in _DEFAULTS.values() for k, v in section.items()}
@@ -2527,6 +2532,119 @@ def _detect_agent(directory: str) -> tuple[str | None, str | None]:
     if os.path.isfile(os.path.join(directory, "AGENTS.md")):
         return "agents", "AGENTS.md"
     return None, None
+
+
+def _build_setup_instructions_mcp() -> str:
+    """Trimmed instructions for agents with the Cartograph MCP server connected.
+
+    The MCP tool schemas already carry the command mechanics and the server
+    instructions carry the what-is-Cartograph framing, so this section only
+    keeps what lives in neither: the domain meanings (the schema enum gives
+    legal values, not judgment) and a pointer to the CLI for operations
+    deliberately left off the MCP surface.
+    """
+    return f"""\
+## Cartograph
+
+Widget library manager. Widgets are reusable code modules with tests,
+examples, and metadata. Installed widgets live under `cg/<widget_id>/`.
+
+The Cartograph MCP server is connected: use its tools for daily widget work
+(create, validate, checkin, status, registry, config, rules). Tool schemas
+carry the command mechanics; this section carries what they don't.
+
+### Domains
+
+{_domain_lines()}
+
+### Beyond the MCP surface
+
+The MCP is intentionally not the full CLI. Cloud publishing and sync,
+rollback, login, and registry management run via the shell. The CLI is the
+source of truth for the complete command surface: `cartograph --help`.
+"""
+
+
+# Per-agent MCP config locations, relative to (project, home). A cartograph
+# server registered in any of these files is evidence the agent session has
+# the MCP surface, so setup can write the trimmed instructions.
+_MCP_CONFIG_PATHS = {
+    "claude": [
+        (".mcp.json", "project"),
+        (os.path.join(".claude", "settings.json"), "project"),
+        (".claude.json", "home"),
+    ],
+    "cursor": [
+        (os.path.join(".cursor", "mcp.json"), "project"),
+        (os.path.join(".cursor", "mcp.json"), "home"),
+    ],
+    "gemini": [
+        (os.path.join(".gemini", "settings.json"), "project"),
+        (os.path.join(".gemini", "settings.json"), "home"),
+    ],
+    "codex": [
+        (os.path.join(".codex", "config.toml"), "home"),
+    ],
+}
+
+
+def _detect_mcp(agent: str | None, directory: str) -> tuple[bool, str | None]:
+    """Detect whether a cartograph MCP server is configured for this agent.
+
+    Evidence-based, not identity-based: reads the agent's actual MCP config
+    files rather than assuming a harness implies MCP. A server whose name
+    contains "cartograph" in any known config counts. Returns
+    (detected, reason).
+    """
+    import json as _json
+
+    def _server_names(node):
+        """Yield server names from every mcpServers mapping in a JSON tree."""
+        if isinstance(node, dict):
+            servers = node.get("mcpServers")
+            if isinstance(servers, dict):
+                yield from servers
+            for value in node.values():
+                yield from _server_names(value)
+        elif isinstance(node, list):
+            for value in node:
+                yield from _server_names(value)
+
+    for rel, base in _MCP_CONFIG_PATHS.get(agent or "", []):
+        root = directory if base == "project" else os.path.expanduser("~")
+        path = os.path.join(root, rel)
+        if not os.path.isfile(path):
+            continue
+        try:
+            with open(path, encoding="utf-8") as f:
+                text = f.read()
+        except OSError:
+            continue
+        if rel.endswith(".toml"):
+            # Codex config: match the table header, not free text.
+            import re as _re
+            found = _re.search(r"\[mcp_servers\.[^\]]*cartograph", text) is not None
+        else:
+            try:
+                tree = _json.loads(text)
+            except ValueError:
+                continue
+            if rel == ".claude.json" and isinstance(tree, dict):
+                # User-scope servers apply everywhere; project-scope entries
+                # only count for THIS project (a cartograph server wired into
+                # some other project is not evidence for this one).
+                projects = tree.get("projects")
+                scoped = {"mcpServers": tree.get("mcpServers", {})}
+                if isinstance(projects, dict):
+                    entry = projects.get(directory) or projects.get(os.path.realpath(directory))
+                    if isinstance(entry, dict):
+                        scoped["project"] = entry
+                tree = scoped
+            found = any("cartograph" in name for name in _server_names(tree))
+        if found:
+            display = os.path.join("~" if base == "home" else ".", rel)
+            return True, f"cartograph MCP server in {display}"
+    return False, None
 
 
 
@@ -3014,8 +3132,23 @@ def cmd_setup(args):
             print()
             return
 
+    # --- Resolve MCP mode: explicit flags win, else evidence-based detection ---
+    mcp_reason = None
+    if getattr(args, "mcp", False):
+        mcp_mode = True
+        mcp_reason = "--mcp flag"
+    elif getattr(args, "no_mcp", False):
+        mcp_mode = False
+    else:
+        mcp_mode, mcp_reason = _detect_mcp(agent, target_dir)
+
+    def _base_instructions():
+        if mcp_mode:
+            return _build_setup_instructions_mcp()
+        return _build_setup_instructions() + _render_commands_block()
+
     # --- Build content ---
-    content = _build_setup_instructions() + _render_commands_block()
+    content = _base_instructions()
     content += _resolve_workflow(getattr(args, "workflow", None))
 
     # --- Resolve target file ---
@@ -3056,8 +3189,7 @@ def cmd_setup(args):
                 # don't silently strip their workflow on overwrite.
                 if workflow_marker in existing and getattr(args, "workflow", None) is None:
                     content_with_workflow = (
-                        _build_setup_instructions() + _render_commands_block()
-                        + _resolve_workflow("default")
+                        _base_instructions() + _resolve_workflow("default")
                     )
                     if agent == "cursor":
                         content_with_workflow = _cursor_mdc(content_with_workflow)
@@ -3070,6 +3202,8 @@ def cmd_setup(args):
                 with open(filepath, "w", encoding="utf-8") as f:
                     f.write(new_file)
                 print(f"\n  Replaced ## Cartograph section in {filepath}{workflow_note}")
+                if mcp_mode:
+                    print(f"  MCP mode: trimmed instructions ({mcp_reason}). Pass --no-mcp for the full reference.")
                 return
             # Section exists - check if user is just adding workflow
             workflow_content = _resolve_workflow(getattr(args, "workflow", None))
@@ -3089,6 +3223,8 @@ def cmd_setup(args):
 
     if detected_reason:
         print(f"\n  Detected {agent} (found {detected_reason})")
+    if mcp_mode:
+        print(f"  MCP mode: trimmed instructions ({mcp_reason}). Pass --no-mcp for the full reference.")
     print(f"  Appended to {filepath}")
     if not getattr(args, "workflow", None):
         print(f"  Tip: add --workflow to include suggested workflow guidelines")
@@ -3668,6 +3804,10 @@ def _build_cli() -> AgentCLI:
                  "help": "Print instructions to stdout instead of writing"},
                 {"name": "--workflow", "nargs": "?", "default": None, "const": "default",
                  "help": "Include workflow (default or custom name from workflows/)"},
+                {"name": "--mcp", "action": "store_true", "default": False,
+                 "help": "Write trimmed instructions for agents with the Cartograph MCP connected (auto-detected from the agent's MCP config if omitted)"},
+                {"name": "--no-mcp", "action": "store_true", "default": False,
+                 "help": "Force the full CLI reference even if a Cartograph MCP server is detected"},
                 {"name": "--overwrite", "action": "store_true", "default": False,
                  "help": "Replace the existing ## Cartograph section in place (preserves everything else in the file)"},
             ],

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -13,11 +13,25 @@ def _clear_agent_env(monkeypatch):
         monkeypatch.delenv(var, raising=False)
 
 
-def _clean_subprocess_env():
-    """Environment for subprocess tests with agent env vars stripped."""
+def _clean_subprocess_env(home=None):
+    """Environment for subprocess tests with agent env vars stripped.
+
+    HOME is pointed at an empty (or caller-supplied) directory so the
+    developer's real ~/.claude.json / ~/.codex/config.toml can't leak MCP
+    detection into the tests.
+    """
+    import tempfile
     env = os.environ.copy()
     for var in ("CLAUDECODE", "GEMINI_CLI", "AGENT"):
         env.pop(var, None)
+    env["HOME"] = str(home) if home else tempfile.mkdtemp()
+    # HOME redirection hides user-site installs, so make the checked-out
+    # package importable in the subprocess explicitly.
+    repo = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    env["PYTHONPATH"] = (
+        os.path.join(repo, "src") + os.pathsep + repo
+        + os.pathsep + env.get("PYTHONPATH", "")
+    )
     return env
 
 
@@ -252,3 +266,176 @@ def test_setup_without_workflow_shows_tip(tmp_path):
         env=_clean_subprocess_env(),
     )
     assert "Tip: add --workflow" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# MCP mode - detection and trimmed instructions
+# ---------------------------------------------------------------------------
+
+def test_detect_mcp_from_project_mcp_json(tmp_path):
+    """A cartograph server in the project .mcp.json is evidence."""
+    import json
+    from cartograph.cli import _detect_mcp
+    (tmp_path / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"cartograph": {"command": "cartograph-mcp"}}}))
+    found, reason = _detect_mcp("claude", str(tmp_path))
+    assert found
+    assert ".mcp.json" in reason
+
+
+def test_detect_mcp_nothing(tmp_path, monkeypatch):
+    """No MCP config anywhere -> not detected."""
+    from cartograph.cli import _detect_mcp
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    found, reason = _detect_mcp("claude", str(tmp_path))
+    assert not found and reason is None
+
+
+def test_detect_mcp_other_project_does_not_count(tmp_path, monkeypatch):
+    """A cartograph server wired into ANOTHER project in ~/.claude.json
+    is not evidence for this one."""
+    import json
+    from cartograph.cli import _detect_mcp
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    (home / ".claude.json").write_text(json.dumps(
+        {"projects": {"/other/project": {"mcpServers": {"cartograph": {}}}}}))
+    found, _ = _detect_mcp("claude", str(tmp_path))
+    assert not found
+
+
+def test_detect_mcp_user_scope_counts(tmp_path, monkeypatch):
+    """User-scope mcpServers in ~/.claude.json applies to every project."""
+    import json
+    from cartograph.cli import _detect_mcp
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    (home / ".claude.json").write_text(json.dumps(
+        {"mcpServers": {"plugin:cartograph:cartograph": {}}}))
+    found, reason = _detect_mcp("claude", str(tmp_path))
+    assert found
+    assert ".claude.json" in reason
+
+
+def test_detect_mcp_codex_toml_header_only(tmp_path, monkeypatch):
+    """Codex config matches the [mcp_servers.*cartograph] table header,
+    not free text mentioning cartograph."""
+    from cartograph.cli import _detect_mcp
+    home = tmp_path / "home"
+    (home / ".codex").mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    cfg = home / ".codex" / "config.toml"
+    cfg.write_text("# cartograph is neat\n[mcp_servers.other]\n")
+    assert not _detect_mcp("codex", str(tmp_path))[0]
+    cfg.write_text("[mcp_servers.cartograph]\ncommand = \"cartograph-mcp\"\n")
+    assert _detect_mcp("codex", str(tmp_path))[0]
+
+
+def test_mcp_instructions_are_trimmed():
+    """MCP variant keeps domains + escape hatch, drops the command catalog."""
+    from cartograph.cli import _build_setup_instructions_mcp
+    content = _build_setup_instructions_mcp()
+    assert "## Cartograph" in content
+    assert "### Domains" in content
+    assert "Beyond the MCP surface" in content
+    assert "### Commands" not in content
+    assert "### Config keys" not in content
+
+
+def test_setup_mcp_flag_writes_trimmed(tmp_path):
+    """--mcp forces the trimmed instructions."""
+    import subprocess
+    os.makedirs(tmp_path / ".claude")
+    result = subprocess.run(
+        ["python", "-m", "cartograph", "setup", "--mcp"],
+        capture_output=True, text=True, encoding="utf-8",
+        errors="replace", cwd=str(tmp_path),
+        env=_clean_subprocess_env(),
+    )
+    assert result.returncode == 0
+    assert "MCP mode" in result.stdout
+    content = (tmp_path / "CLAUDE.md").read_text()
+    assert "Beyond the MCP surface" in content
+    assert "### Commands" not in content
+
+
+def test_setup_autodetects_mcp_from_project_config(tmp_path):
+    """Bare setup with a cartograph server in .mcp.json writes trimmed
+    instructions and says why."""
+    import json
+    import subprocess
+    os.makedirs(tmp_path / ".claude")
+    (tmp_path / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"cartograph": {"command": "cartograph-mcp"}}}))
+    result = subprocess.run(
+        ["python", "-m", "cartograph", "setup"],
+        capture_output=True, text=True, encoding="utf-8",
+        errors="replace", cwd=str(tmp_path),
+        env=_clean_subprocess_env(),
+    )
+    assert result.returncode == 0
+    assert "MCP mode" in result.stdout
+    assert ".mcp.json" in result.stdout
+    content = (tmp_path / "CLAUDE.md").read_text()
+    assert "Beyond the MCP surface" in content
+    assert "### Commands" not in content
+
+
+def test_setup_no_mcp_overrides_detection(tmp_path):
+    """--no-mcp forces the full reference even when a server is configured."""
+    import json
+    import subprocess
+    os.makedirs(tmp_path / ".claude")
+    (tmp_path / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"cartograph": {"command": "cartograph-mcp"}}}))
+    result = subprocess.run(
+        ["python", "-m", "cartograph", "setup", "--no-mcp"],
+        capture_output=True, text=True, encoding="utf-8",
+        errors="replace", cwd=str(tmp_path),
+        env=_clean_subprocess_env(),
+    )
+    assert result.returncode == 0
+    content = (tmp_path / "CLAUDE.md").read_text()
+    assert "### Commands" in content
+    assert "Beyond the MCP surface" not in content
+
+
+def test_setup_mcp_with_workflow(tmp_path):
+    """Workflow layer composes with the MCP variant unchanged."""
+    import subprocess
+    os.makedirs(tmp_path / ".claude")
+    result = subprocess.run(
+        ["python", "-m", "cartograph", "setup", "--mcp", "--workflow"],
+        capture_output=True, text=True, encoding="utf-8",
+        errors="replace", cwd=str(tmp_path),
+        env=_clean_subprocess_env(),
+    )
+    assert result.returncode == 0
+    content = (tmp_path / "CLAUDE.md").read_text()
+    assert "Beyond the MCP surface" in content
+    assert "### Workflow" in content
+
+
+def test_setup_overwrite_preserves_mcp_mode(tmp_path):
+    """--overwrite re-detects MCP and keeps the trimmed form + workflow."""
+    import json
+    import subprocess
+    os.makedirs(tmp_path / ".claude")
+    (tmp_path / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"cartograph": {}}}))
+    env = _clean_subprocess_env()
+    subprocess.run(
+        ["python", "-m", "cartograph", "setup", "--workflow"],
+        capture_output=True, text=True, encoding="utf-8",
+        errors="replace", cwd=str(tmp_path), env=env)
+    result = subprocess.run(
+        ["python", "-m", "cartograph", "setup", "--overwrite"],
+        capture_output=True, text=True, encoding="utf-8",
+        errors="replace", cwd=str(tmp_path), env=env)
+    assert result.returncode == 0
+    content = (tmp_path / "CLAUDE.md").read_text()
+    assert "Beyond the MCP surface" in content
+    assert "### Commands" not in content
+    assert "### Workflow" in content

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -13,6 +13,13 @@ def _clear_agent_env(monkeypatch):
         monkeypatch.delenv(var, raising=False)
 
 
+def _set_home(monkeypatch, path):
+    """Redirect the home directory cross-platform: expanduser('~') reads
+    HOME on POSIX but USERPROFILE on Windows."""
+    monkeypatch.setenv("HOME", str(path))
+    monkeypatch.setenv("USERPROFILE", str(path))
+
+
 def _clean_subprocess_env(home=None):
     """Environment for subprocess tests with agent env vars stripped.
 
@@ -24,7 +31,9 @@ def _clean_subprocess_env(home=None):
     env = os.environ.copy()
     for var in ("CLAUDECODE", "GEMINI_CLI", "AGENT"):
         env.pop(var, None)
-    env["HOME"] = str(home) if home else tempfile.mkdtemp()
+    fake_home = str(home) if home else tempfile.mkdtemp()
+    env["HOME"] = fake_home
+    env["USERPROFILE"] = fake_home
     # HOME redirection hides user-site installs, so make the checked-out
     # package importable in the subprocess explicitly.
     repo = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -286,7 +295,7 @@ def test_detect_mcp_from_project_mcp_json(tmp_path):
 def test_detect_mcp_nothing(tmp_path, monkeypatch):
     """No MCP config anywhere -> not detected."""
     from cartograph.cli import _detect_mcp
-    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    _set_home(monkeypatch, tmp_path / "home")
     found, reason = _detect_mcp("claude", str(tmp_path))
     assert not found and reason is None
 
@@ -298,7 +307,7 @@ def test_detect_mcp_other_project_does_not_count(tmp_path, monkeypatch):
     from cartograph.cli import _detect_mcp
     home = tmp_path / "home"
     home.mkdir()
-    monkeypatch.setenv("HOME", str(home))
+    _set_home(monkeypatch, home)
     (home / ".claude.json").write_text(json.dumps(
         {"projects": {"/other/project": {"mcpServers": {"cartograph": {}}}}}))
     found, _ = _detect_mcp("claude", str(tmp_path))
@@ -311,7 +320,7 @@ def test_detect_mcp_user_scope_counts(tmp_path, monkeypatch):
     from cartograph.cli import _detect_mcp
     home = tmp_path / "home"
     home.mkdir()
-    monkeypatch.setenv("HOME", str(home))
+    _set_home(monkeypatch, home)
     (home / ".claude.json").write_text(json.dumps(
         {"mcpServers": {"plugin:cartograph:cartograph": {}}}))
     found, reason = _detect_mcp("claude", str(tmp_path))
@@ -325,7 +334,7 @@ def test_detect_mcp_codex_toml_header_only(tmp_path, monkeypatch):
     from cartograph.cli import _detect_mcp
     home = tmp_path / "home"
     (home / ".codex").mkdir(parents=True)
-    monkeypatch.setenv("HOME", str(home))
+    _set_home(monkeypatch, home)
     cfg = home / ".codex" / "config.toml"
     cfg.write_text("# cartograph is neat\n[mcp_servers.other]\n")
     assert not _detect_mcp("codex", str(tmp_path))[0]


### PR DESCRIPTION
## What

`cartograph setup` now writes a trimmed ~30-line instructions section when the agent has the Cartograph MCP server connected, instead of the full ~170-line CLI reference.

**Trim rule:** cut anything the MCP tool schemas or server instructions already say; keep what lives in neither:
- the domains table (schema enums give legal values, not judgment)
- a "Beyond the MCP surface" pointer to shell-only operations (cloud publish/sync, rollback, login, registry management)
- the `--workflow` layer composes unchanged

## Detection

Evidence-based, not identity-based - no "claude implies MCP" table to drift. Setup reads the detected agent's real MCP config for a server named \*cartograph\*:

- `.mcp.json` (project), `~/.claude.json` (user-scope servers + **this** project's entry only - a server wired into another project doesn't count)
- `.cursor/mcp.json` (project + home)
- `.gemini/settings.json` (project + home)
- `~/.codex/config.toml` (matches `[mcp_servers.*cartograph]` table headers, not free text)

`--mcp` / `--no-mcp` override in both directions; the chosen mode and its reason are printed.

## Tests

11 new tests (detection scoping, trimmed content, flag overrides, workflow composition, overwrite preservation). Subprocess test env made hermetic: HOME redirected so the developer's real `~/.claude.json` can't leak detection into the suite. Wheel-install smoke of `setup --print` in both modes passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4Y61587L5cXmAZuEVWSFS