### PR TITLE
fix: macOS bug hunt - OS metadata filtering, java stub detection, python-on-PATH portability

### DIFF
--- a/cg/universal_build_artifact_ignore_python/.validation_stamp.json
+++ b/cg/universal_build_artifact_ignore_python/.validation_stamp.json
@@ -1,1 +1,1 @@
-{"fingerprint": "6479e1070b96e4ec082db3afe6588b28d4392e9bb9987875a872dd4047117f48", "stamped_at": "2026-05-07T02:12:48.088717+00:00", "language": "python", "engine_version": 1, "runtime": "python 3.14.4", "test_results": {}, "validated_at": "2026-05-07T02:12:48.088395+00:00"}
+{"fingerprint": "8144baba16f2a34a1555ac59c99821fa7745efd2c06ffc82ffc38507dc9e482f", "stamped_at": "2026-07-08T15:10:51.747785+00:00", "language": "python", "engine_version": 1, "runtime": "python 3.14.6", "test_results": {}, "validated_at": "2026-07-08T15:10:51.747492+00:00"}

--- a/cg/universal_build_artifact_ignore_python/src/build_artifact_ignore.py
+++ b/cg/universal_build_artifact_ignore_python/src/build_artifact_ignore.py
@@ -17,11 +17,47 @@ _UNIVERSAL: frozenset[str] = frozenset({
     ".hg",
     ".svn",
     ".DS_Store",
+    "__MACOSX",
+    "Thumbs.db",
+    "desktop.ini",
     ".idea",
     ".vscode",
     ".cache",
     ".tmp",
 })
+
+
+# OS metadata the desktop shell scatters into trees behind the user's back.
+# Unlike the artifact-dir sets these need file-level matching: macOS
+# AppleDouble resource forks are named `._<original file>`, so no exact-name
+# set can express them.
+_OS_METADATA_NAMES: frozenset[str] = frozenset({
+    ".DS_Store", "__MACOSX", "Thumbs.db", "desktop.ini",
+})
+_OS_METADATA_PREFIXES: tuple[str, ...] = ("._",)
+
+
+def is_os_metadata(name: str) -> bool:
+    """True if the basename of ``name`` is OS-scattered metadata.
+
+    Covers macOS ``.DS_Store``, AppleDouble ``._*`` resource forks, and
+    ``__MACOSX`` zip directories, plus Windows ``Thumbs.db`` and
+    ``desktop.ini``. Accepts a bare basename or a path.
+    """
+    base = os.path.basename(name.rstrip("/\\"))
+    if base in _OS_METADATA_NAMES:
+        return True
+    return base.startswith(_OS_METADATA_PREFIXES)
+
+
+def os_metadata_glob_patterns() -> tuple[str, ...]:
+    """The same set as glob patterns, for ``shutil.ignore_patterns``-style
+    consumers that match names against fnmatch patterns.
+
+    Note ``._*`` also matches a directory literally named ``._`` -
+    acceptable, since that name only appears as AppleDouble spillage.
+    """
+    return (".DS_Store", "._*", "__MACOSX", "Thumbs.db", "desktop.ini")
 
 
 # Per-language artifact dirs. Keys are short language tags; consumers
@@ -142,6 +178,8 @@ def should_skip(
     Designed for use inside ``os.walk`` loops or against a relative
     path inside a zip-build loop. ``prefixes`` is checked with leading
     dots stripped (so ``nimcache`` matches ``.nimcache_example``).
+    OS metadata (``is_os_metadata``) is always skipped regardless of the
+    exclude sets passed in.
     """
     exclude_set = set(excludes)
     prefix_tuple = tuple(prefixes)
@@ -150,6 +188,8 @@ def should_skip(
         if not part:
             continue
         if part in exclude_set:
+            return True
+        if is_os_metadata(part):
             return True
         if prefix_tuple and _matches_prefix(part, prefix_tuple):
             return True
@@ -164,12 +204,14 @@ def filter_dirs(
     """Return a new list with excluded entries removed. Convenience
     wrapper for the common ``dirs[:] = filter_dirs(dirs, excludes)``
     pattern inside ``os.walk``. ``prefixes`` is checked with leading
-    dots stripped."""
+    dots stripped. OS metadata dirs (e.g. ``__MACOSX``) are always
+    removed."""
     exclude_set = set(excludes)
     prefix_tuple = tuple(prefixes)
     return [
         d for d in dirs
         if d not in exclude_set
+        and not is_os_metadata(d)
         and not (prefix_tuple and _matches_prefix(d, prefix_tuple))
     ]
 

--- a/cg/universal_build_artifact_ignore_python/tests/test_build_artifact_ignore.py
+++ b/cg/universal_build_artifact_ignore_python/tests/test_build_artifact_ignore.py
@@ -193,3 +193,51 @@ def test_walk_integration(tmp_path):
     assert any("code.py" in v for v in visited)
     assert not any("huge.bin" in v for v in visited)
     assert not any(".git" in v for v in visited)
+
+
+# ---------------------------------------------------------------------------
+# OS metadata
+# ---------------------------------------------------------------------------
+
+def test_is_os_metadata_names():
+    from src.build_artifact_ignore import is_os_metadata
+    assert is_os_metadata(".DS_Store")
+    assert is_os_metadata("__MACOSX")
+    assert is_os_metadata("Thumbs.db")
+    assert is_os_metadata("desktop.ini")
+
+
+def test_is_os_metadata_appledouble_prefix():
+    from src.build_artifact_ignore import is_os_metadata
+    assert is_os_metadata("._module.py")
+    assert is_os_metadata("._")
+    assert not is_os_metadata("_module.py")
+    assert not is_os_metadata(".module.py")
+    assert not is_os_metadata("module.py")
+
+
+def test_is_os_metadata_accepts_paths():
+    from src.build_artifact_ignore import is_os_metadata
+    assert is_os_metadata("src/._module.py")
+    assert is_os_metadata(os.path.join("a", "b", ".DS_Store"))
+    assert not is_os_metadata("src/module.py")
+
+
+def test_os_metadata_glob_patterns_cover_names():
+    import fnmatch
+    from src.build_artifact_ignore import os_metadata_glob_patterns
+    patterns = os_metadata_glob_patterns()
+    for name in (".DS_Store", "._module.py", "__MACOSX", "Thumbs.db", "desktop.ini"):
+        assert any(fnmatch.fnmatch(name, p) for p in patterns), name
+    assert not any(fnmatch.fnmatch("module.py", p) for p in patterns)
+
+
+def test_should_skip_os_metadata_without_explicit_excludes():
+    assert should_skip("src/._module.py", excludes=())
+    assert should_skip("__MACOSX/src/module.py", excludes=())
+    assert not should_skip("src/module.py", excludes=())
+
+
+def test_filter_dirs_removes_os_metadata():
+    result = filter_dirs(["src", "__MACOSX", "._junk"], excludes=())
+    assert result == ["src"]

--- a/cg/universal_build_artifact_ignore_python/widget.json
+++ b/cg/universal_build_artifact_ignore_python/widget.json
@@ -2,7 +2,7 @@
   "meta": {
     "id": "universal-build-artifact-ignore-python",
     "name": "Build Artifact Ignore",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "domain": "universal",
     "tags": [
       "filesystem",
@@ -25,7 +25,7 @@
   },
   "validation": {
     "engine_version": 1,
-    "validated_at": "2026-05-07T02:12:53.132108+00:00",
-    "runtime": "python 3.14.4"
+    "validated_at": "2026-07-08T15:10:52.244589+00:00",
+    "runtime": "python 3.14.6"
   }
 }

--- a/src/cartograph/checkin.py
+++ b/src/cartograph/checkin.py
@@ -28,7 +28,7 @@ import logging
 import os
 import shutil
 
-from .engine import semver_key as _semver_key
+from .engine import semver_key as _semver_key, _is_os_metadata
 from .languages import get_engine
 from .safefs import widget_lock, staged_dir, LockTimeout
 from .scaffolding import _library_notes as _canonical_library_notes
@@ -83,6 +83,20 @@ def _artifact_skip_set(language: str | None) -> set[str]:
         return set(excludes_for(language=language))
     except ImportError:
         return {"__pycache__", ".pytest_cache", "node_modules", ".git"}
+
+
+def _os_metadata_patterns() -> tuple:
+    """Glob patterns for OS-scattered metadata (.DS_Store, AppleDouble
+    `._*`, __MACOSX, Thumbs.db). Finder drops these into working copies;
+    without this filter they get checked into the library and propagate
+    to every consumer on install."""
+    try:
+        from cg.universal_build_artifact_ignore_python.src.build_artifact_ignore import (
+            os_metadata_glob_patterns,
+        )
+        return os_metadata_glob_patterns()
+    except ImportError:
+        return (".DS_Store", "._*", "__MACOSX", "Thumbs.db", "desktop.ini")
 
 
 def _restore_library_notes(manifest_path: str) -> None:
@@ -421,10 +435,12 @@ def checkin(carto, path: str, reason: str = "", version_bump: str = "minor",
         "history", "changelog.json", _STAMP_FILE, _DEP_STAMP_FILE,
         ".cartograph_source",
     }
+    os_metadata = _os_metadata_patterns()
     copy_ignore = shutil.ignore_patterns(
-        *artifact_skips, "*.pyc", _DEP_STAMP_FILE, ".cartograph_source")
+        *artifact_skips, *os_metadata, "*.pyc", _DEP_STAMP_FILE,
+        ".cartograph_source")
     snapshot_ignore = shutil.ignore_patterns(
-        *artifact_skips, "*.pyc",
+        *artifact_skips, *os_metadata, "*.pyc",
         "history", "changelog.json", _STAMP_FILE, _DEP_STAMP_FILE,
         ".cartograph_source",
     )
@@ -684,9 +700,10 @@ def _modified_files(installed_path: str, library_path: str) -> dict:
             if not os.path.isdir(root_path):
                 continue
             for root, dirs, files in os.walk(root_path):
-                dirs[:] = [d for d in dirs if d != "__pycache__"]
+                dirs[:] = [d for d in dirs
+                           if d != "__pycache__" and not _is_os_metadata(d)]
                 for name in files:
-                    if name.endswith(".pyc"):
+                    if name.endswith(".pyc") or _is_os_metadata(name):
                         continue
                     full = os.path.join(root, name)
                     rel = os.path.relpath(full, base)

--- a/src/cartograph/contamination.py
+++ b/src/cartograph/contamination.py
@@ -19,6 +19,8 @@ import logging
 import os
 import re
 
+from .engine import _is_os_metadata
+
 log = logging.getLogger("cartograph")
 
 
@@ -157,14 +159,16 @@ def scan_blueprint_contamination(path: str) -> dict:
 
 
 def _collect_files(root: str) -> list[str]:
-    """Return all files under `root` (any extension). Skips __pycache__."""
+    """Return all files under `root` (any extension). Skips __pycache__
+    and OS metadata (.DS_Store, AppleDouble `._*` forks, __MACOSX)."""
     if not os.path.isdir(root):
         return []
     out: list[str] = []
     for dirpath, dirnames, filenames in os.walk(root):
-        dirnames[:] = [d for d in dirnames if d != "__pycache__"]
+        dirnames[:] = [d for d in dirnames
+                       if d != "__pycache__" and not _is_os_metadata(d)]
         for name in filenames:
-            if name.endswith(".pyc") or name == ".DS_Store":
+            if name.endswith(".pyc") or _is_os_metadata(name):
                 continue
             out.append(os.path.join(dirpath, name))
     return out

--- a/src/cartograph/engine.py
+++ b/src/cartograph/engine.py
@@ -10,6 +10,22 @@ import logging
 log = logging.getLogger("cartograph")
 
 
+def _is_os_metadata(name: str) -> bool:
+    """OS-scattered metadata (.DS_Store, AppleDouble `._*`, __MACOSX,
+    Thumbs.db). These appear behind the user's back (Finder, zip round
+    trips) and must never count as widget content - otherwise a stray
+    .DS_Store flips a widget to "locally modified" and `._*` forks get
+    hashed, diffed, and checked in."""
+    try:
+        from cg.universal_build_artifact_ignore_python.src.build_artifact_ignore import (
+            is_os_metadata,
+        )
+        return is_os_metadata(name)
+    except ImportError:
+        return name in (".DS_Store", "__MACOSX", "Thumbs.db",
+                        "desktop.ini") or name.startswith("._")
+
+
 def calculate_implementation_hash(path: str) -> str | None:
     """Stable MD5 over src/, tests/, examples/, and python/ bytes.
 
@@ -35,9 +51,10 @@ def calculate_implementation_hash(path: str) -> str | None:
             continue
         found_any = True
         for root, dirs, files in os.walk(sub_path):
-            dirs[:] = [d for d in dirs if d != '__pycache__']
+            dirs[:] = [d for d in dirs
+                       if d != '__pycache__' and not _is_os_metadata(d)]
             for name in sorted(files):
-                if name.endswith('.pyc'):
+                if name.endswith('.pyc') or _is_os_metadata(name):
                     continue
                 filepath = os.path.join(root, name)
                 with open(filepath, 'rb') as f:
@@ -312,9 +329,10 @@ class Cartograph:
                 if not os.path.exists(root_path):
                     continue
                 for root, dirs, files in os.walk(root_path):
-                    dirs[:] = [d for d in dirs if d != '__pycache__']
+                    dirs[:] = [d for d in dirs
+                               if d != '__pycache__' and not _is_os_metadata(d)]
                     for fname in files:
-                        if fname.endswith('.pyc'):
+                        if fname.endswith('.pyc') or _is_os_metadata(fname):
                             continue
                         full = os.path.join(root, fname)
                         rel = os.path.relpath(full, base)

--- a/src/cartograph/languages/java.py
+++ b/src/cartograph/languages/java.py
@@ -228,6 +228,28 @@ class JavaEngine(LanguageEngine):
 
     # ---- toolchain ---------------------------------------------------------
 
+    # Cached result of the functional `java -version` probe. macOS ships a
+    # /usr/bin/java stub that exists on PATH with no JDK installed - it only
+    # prints "Unable to locate a Java Runtime". PATH resolution alone is a
+    # lie there, so availability must actually run the binary. None = not
+    # probed yet.
+    _java_probe_ok: bool | None = None
+
+    def check_available(self) -> tuple[bool, str]:
+        ok, msg = super().check_available()
+        if not ok:
+            return ok, msg
+        if JavaEngine._java_probe_ok is None:
+            JavaEngine._java_probe_ok = self.runtime_version() is not None
+        if not JavaEngine._java_probe_ok:
+            return False, (
+                "Java engine requires a working JDK - the `java` binary on "
+                "PATH could not report a version (on macOS this is Apple's "
+                "no-JDK stub). Install a JDK 21+ - adoptium.net "
+                "(or set paths.java in `cartograph config`)"
+            )
+        return True, ""
+
     def runtime_version(self) -> str | None:
         try:
             res = self._run(["java", "-version"], cwd=".", timeout=15)

--- a/src/cartograph/languages/python.py
+++ b/src/cartograph/languages/python.py
@@ -10,6 +10,17 @@ import sys
 import time
 
 from .base import LanguageEngine, _dep_bare_name, log
+from ..engine import _is_os_metadata
+
+
+def _py_files(path: str, subdir: str) -> list:
+    """All .py files under a widget subdir, minus OS metadata.
+
+    AppleDouble resource forks are named `._<original>.py`, so a bare
+    `**/*.py` glob picks them up - they are binary garbage, not source.
+    """
+    found = glob.glob(os.path.join(path, subdir, "**", "*.py"), recursive=True)
+    return [f for f in found if not _is_os_metadata(os.path.basename(f))]
 
 # Starter file contents for scaffold
 _SRC_INIT = "# Package marker - add explicit exports here once the public API is stable.\n"
@@ -137,7 +148,7 @@ class PythonEngine(LanguageEngine):
             errors.append("src/__init__.py is missing — add an empty one so the package is importable")
 
         # 2. No print() calls in src/ (AST-based: ignores docstrings and comments)
-        src_files = glob.glob(os.path.join(path, "src", "**", "*.py"), recursive=True)
+        src_files = _py_files(path, "src")
         for fpath in src_files:
             for lineno in self._find_print_calls(fpath):
                 rel = os.path.relpath(fpath, path)
@@ -211,9 +222,9 @@ class PythonEngine(LanguageEngine):
                 if f.endswith(".py"):
                     own_modules.add(f[:-3])
 
-        src_files = glob.glob(os.path.join(path, "src", "**", "*.py"), recursive=True)
-        test_files = glob.glob(os.path.join(path, "tests", "**", "*.py"), recursive=True)
-        example_files = glob.glob(os.path.join(path, "examples", "**", "*.py"), recursive=True)
+        src_files = _py_files(path, "src")
+        test_files = _py_files(path, "tests")
+        example_files = _py_files(path, "examples")
 
         for fpath in src_files + test_files + example_files:
             rel = os.path.relpath(fpath, path)
@@ -259,9 +270,18 @@ class PythonEngine(LanguageEngine):
                     if any(len(o) >= 2 for o in octets):
                         blocks.append(f"Hardcoded IP in {rel}:{line_no}: {m.group()}")
 
-            # AST-based checks
+            # AST-based checks. A src/ file that doesn't parse cannot have
+            # been exercised by tests or scanned for contamination - block
+            # instead of silently skipping it.
             try:
                 tree = ast.parse(code)
+            except SyntaxError as e:
+                if is_src:
+                    blocks.append(
+                        f"src file {rel} is not valid Python "
+                        f"(line {e.lineno}: {e.msg}) - fix or remove it"
+                    )
+                continue
             except Exception:
                 continue
 
@@ -547,7 +567,10 @@ class PythonEngine(LanguageEngine):
         sub = os.path.join(widget_path, subdir)
         if not os.path.isdir(sub):
             return self._ok()
-        py_files = sorted(glob.glob(os.path.join(sub, "*.py")))
+        py_files = sorted(
+            f for f in glob.glob(os.path.join(sub, "*.py"))
+            if not _is_os_metadata(os.path.basename(f))
+        )
         if not py_files:
             return self._ok()
 

--- a/src/cartograph/rules.py
+++ b/src/cartograph/rules.py
@@ -284,7 +284,7 @@ Cartograph's way (the quality guarantee), once yours (your preferences).
 
     import subprocess
     result = subprocess.run(
-        ["python", "-m", "pytest", "tests/", "--timeout=120", "-x"],
+        [sys.executable, "-m", "pytest", "tests/", "--timeout=120", "-x"],
         capture_output=True, text=True, cwd=widget_path,
     )
     if result.returncode != 0:

--- a/tests/test_checkin.py
+++ b/tests/test_checkin.py
@@ -681,3 +681,40 @@ def test_checkin_malformed_version_errors(carto_tmp, modified_widget):
         result = carto_tmp.checkin(modified_widget, reason="x")
     assert result["status"] == "error"
     assert "malformed version" in result["message"].lower()
+
+
+# ---------------------------------------------------------------------------
+# OS metadata (macOS Finder droppings) must never count as widget content
+# ---------------------------------------------------------------------------
+
+class TestOsMetadataIgnored:
+    def _make_widget_dirs(self, tmp_path):
+        src = tmp_path / "w" / "src"
+        src.mkdir(parents=True)
+        (src / "module.py").write_text("def f():\n    return 1\n")
+        return tmp_path / "w"
+
+    def test_hash_ignores_ds_store_and_appledouble(self, tmp_path):
+        from cartograph.engine import calculate_implementation_hash
+        w = self._make_widget_dirs(tmp_path)
+        clean = calculate_implementation_hash(str(w))
+        (w / "src" / ".DS_Store").write_bytes(b"finder junk")
+        (w / "src" / "._module.py").write_bytes(b"\x00\x05\x16\x07fork")
+        (w / "src" / "__MACOSX").mkdir()
+        (w / "src" / "__MACOSX" / "extra").write_bytes(b"zip junk")
+        assert calculate_implementation_hash(str(w)) == clean
+
+    def test_hash_still_sees_real_changes(self, tmp_path):
+        from cartograph.engine import calculate_implementation_hash
+        w = self._make_widget_dirs(tmp_path)
+        clean = calculate_implementation_hash(str(w))
+        (w / "src" / "module.py").write_text("def f():\n    return 2\n")
+        assert calculate_implementation_hash(str(w)) != clean
+
+    def test_checkin_copy_excludes_os_metadata(self):
+        import fnmatch
+        from cartograph.checkin import _os_metadata_patterns
+        patterns = _os_metadata_patterns()
+        for junk in (".DS_Store", "._module.py", "__MACOSX", "Thumbs.db"):
+            assert any(fnmatch.fnmatch(junk, p) for p in patterns), junk
+        assert not any(fnmatch.fnmatch("module.py", p) for p in patterns)

--- a/tests/test_contamination.py
+++ b/tests/test_contamination.py
@@ -340,6 +340,12 @@ def _skip_if_missing(lang):
     tool = NEEDS_TOOL.get(lang)
     if tool and not shutil.which(tool):
         pytest.skip(f"{tool} not installed")
+    if lang == "java":
+        # macOS ships a /usr/bin/java stub with no JDK behind it, so a PATH
+        # hit isn't proof java can run - probe it like the engine does.
+        from cartograph.languages import get_engine
+        if get_engine("java").runtime_version() is None:
+            pytest.skip("java on PATH is not a working JDK (macOS no-JDK stub)")
 
 
 class TestContaminationStandard:
@@ -2698,3 +2704,54 @@ class TestSpiceSpecific:
             'R2 a b {r}  ; secret = "do-not-flag-this-comment"\n')
         assert not any("credential" in b.lower() for b in result["blocks"]), \
             f"credential in comment must not block: {result['blocks']}"
+
+
+# ---------------------------------------------------------------------------
+# macOS filesystem cruft and unparseable sources
+# ---------------------------------------------------------------------------
+
+class TestMacosCruft:
+    def test_appledouble_file_in_src_is_ignored(self, tmp_path):
+        wdir = _make_widget(tmp_path, "python", "mod.py", "def f():\n    return 1\n")
+        with open(os.path.join(wdir, "src", "._mod.py"), "wb") as f:
+            f.write(b"\x00\x05\x16\x07binary resource fork")
+        result = PythonEngine().scan_contamination(
+            wdir, {"language": "python", "dependencies": []})
+        assert result["blocks"] == []
+
+    def test_unparseable_src_file_blocks(self, tmp_path):
+        wdir = _make_widget(tmp_path, "python", "mod.py", "def broken(:\n")
+        result = PythonEngine().scan_contamination(
+            wdir, {"language": "python", "dependencies": []})
+        assert any("not valid Python" in b for b in result["blocks"]), result
+
+    def test_unparseable_test_file_does_not_block(self, tmp_path):
+        wdir = _make_widget(tmp_path, "python", "mod.py",
+                            "def f():\n    return 1\n",
+                            test_code="def broken(:\n")
+        result = PythonEngine().scan_contamination(
+            wdir, {"language": "python", "dependencies": []})
+        assert not any("not valid Python" in b for b in result["blocks"])
+
+
+class TestJavaStubDetection:
+    def test_check_available_rejects_non_working_java(self, monkeypatch):
+        """macOS's /usr/bin/java stub resolves on PATH but can't run."""
+        engine = JavaEngine()
+        monkeypatch.setattr(JavaEngine, "_java_probe_ok", None)
+        monkeypatch.setattr(JavaEngine, "runtime_version", lambda self: None)
+        monkeypatch.setattr(type(engine).__mro__[1], "check_available",
+                            lambda self: (True, ""))
+        ok, msg = engine.check_available()
+        assert ok is False
+        assert "JDK" in msg
+
+    def test_check_available_accepts_working_java(self, monkeypatch):
+        engine = JavaEngine()
+        monkeypatch.setattr(JavaEngine, "_java_probe_ok", None)
+        monkeypatch.setattr(JavaEngine, "runtime_version",
+                            lambda self: "java 21.0.1")
+        monkeypatch.setattr(type(engine).__mro__[1], "check_available",
+                            lambda self: (True, ""))
+        ok, msg = engine.check_available()
+        assert ok is True

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,4 +1,5 @@
 """Tests for custom validation rules system."""
+import sys
 import json
 import os
 
@@ -348,7 +349,7 @@ def test_cli_rules_init(tmp_path):
     """cartograph rules init should create the rules file."""
     import subprocess
     result = subprocess.run(
-        ["python", "-m", "cartograph", "rules", "init", "--language", "python"],
+        [sys.executable, "-m", "cartograph", "rules", "init", "--language", "python"],
         capture_output=True, text=True, encoding="utf-8",
         errors="replace", cwd=str(tmp_path),
     )
@@ -364,12 +365,12 @@ def test_cli_rules_init_already_exists(tmp_path):
     """Running init twice should tell you the file exists."""
     import subprocess
     subprocess.run(
-        ["python", "-m", "cartograph", "rules", "init", "--language", "python"],
+        [sys.executable, "-m", "cartograph", "rules", "init", "--language", "python"],
         capture_output=True, text=True, encoding="utf-8",
         errors="replace", cwd=str(tmp_path),
     )
     result = subprocess.run(
-        ["python", "-m", "cartograph", "rules", "init", "--language", "python"],
+        [sys.executable, "-m", "cartograph", "rules", "init", "--language", "python"],
         capture_output=True, text=True, encoding="utf-8",
         errors="replace", cwd=str(tmp_path),
     )
@@ -382,7 +383,7 @@ def test_cli_rules_reset(tmp_path):
     import subprocess
     # Init, then break it
     subprocess.run(
-        ["python", "-m", "cartograph", "rules", "init", "--language", "python"],
+        [sys.executable, "-m", "cartograph", "rules", "init", "--language", "python"],
         capture_output=True, text=True, encoding="utf-8",
         errors="replace", cwd=str(tmp_path),
     )
@@ -392,7 +393,7 @@ def test_cli_rules_reset(tmp_path):
     # Reset without --confirm should block as an error (CLI contract:
     # refusals exit non-zero so agents/CI notice).
     result = subprocess.run(
-        ["python", "-m", "cartograph", "rules", "reset", "--language", "python"],
+        [sys.executable, "-m", "cartograph", "rules", "reset", "--language", "python"],
         capture_output=True, text=True, encoding="utf-8",
         errors="replace", cwd=str(tmp_path),
     )
@@ -401,7 +402,7 @@ def test_cli_rules_reset(tmp_path):
 
     # Reset with --confirm should succeed
     result = subprocess.run(
-        ["python", "-m", "cartograph", "rules", "reset", "--language", "python", "--confirm"],
+        [sys.executable, "-m", "cartograph", "rules", "reset", "--language", "python", "--confirm"],
         capture_output=True, text=True, encoding="utf-8",
         errors="replace", cwd=str(tmp_path),
     )
@@ -418,7 +419,7 @@ def test_cli_rules_list_shows_global(tmp_path):
     """Listing should show global rules that were auto-created."""
     import subprocess
     result = subprocess.run(
-        ["python", "-m", "cartograph", "rules"],
+        [sys.executable, "-m", "cartograph", "rules"],
         capture_output=True, text=True, encoding="utf-8",
         errors="replace", cwd=str(tmp_path),
     )

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,4 +1,5 @@
 """Tests for the setup command - auto-detection, write, print, workflows."""
+import sys
 import os
 
 import pytest
@@ -138,7 +139,7 @@ def test_setup_print_mode(tmp_path):
     import subprocess
     os.makedirs(tmp_path / ".claude")
     result = subprocess.run(
-        ["python", "-m", "cartograph", "setup", "--print"],
+        [sys.executable, "-m", "cartograph", "setup", "--print"],
         capture_output=True, text=True, encoding="utf-8",
         errors="replace", cwd=str(tmp_path),
         env=_clean_subprocess_env(),
@@ -154,7 +155,7 @@ def test_setup_writes_to_detected_agent(tmp_path):
     import subprocess
     os.makedirs(tmp_path / ".claude")
     result = subprocess.run(
-        ["python", "-m", "cartograph", "setup"],
+        [sys.executable, "-m", "cartograph", "setup"],
         capture_output=True, text=True, encoding="utf-8",
         errors="replace", cwd=str(tmp_path),
         env=_clean_subprocess_env(),
@@ -173,7 +174,7 @@ def test_setup_appends_not_replaces(tmp_path):
     existing = "# My Project\n\nSome existing content.\n"
     (tmp_path / "CLAUDE.md").write_text(existing)
     result = subprocess.run(
-        ["python", "-m", "cartograph", "setup"],
+        [sys.executable, "-m", "cartograph", "setup"],
         capture_output=True, text=True, encoding="utf-8",
         errors="replace", cwd=str(tmp_path),
         env=_clean_subprocess_env(),
@@ -190,14 +191,14 @@ def test_setup_duplicate_detection(tmp_path):
     os.makedirs(tmp_path / ".claude")
     # First run
     subprocess.run(
-        ["python", "-m", "cartograph", "setup"],
+        [sys.executable, "-m", "cartograph", "setup"],
         capture_output=True, text=True, encoding="utf-8",
         errors="replace", cwd=str(tmp_path),
         env=_clean_subprocess_env(),
     )
     # Second run
     result = subprocess.run(
-        ["python", "-m", "cartograph", "setup"],
+        [sys.executable, "-m", "cartograph", "setup"],
         capture_output=True, text=True, encoding="utf-8",
         errors="replace", cwd=str(tmp_path),
         env=_clean_subprocess_env(),
@@ -210,7 +211,7 @@ def test_setup_custom_file(tmp_path):
     """--file should write to a custom filename."""
     import subprocess
     result = subprocess.run(
-        ["python", "-m", "cartograph", "setup", "--file", "opencode.md"],
+        [sys.executable, "-m", "cartograph", "setup", "--file", "opencode.md"],
         capture_output=True, text=True, encoding="utf-8",
         errors="replace", cwd=str(tmp_path),
         env=_clean_subprocess_env(),
@@ -225,7 +226,7 @@ def test_setup_explicit_agent(tmp_path):
     """--agent should override auto-detection."""
     import subprocess
     result = subprocess.run(
-        ["python", "-m", "cartograph", "setup", "--agent", "codex"],
+        [sys.executable, "-m", "cartograph", "setup", "--agent", "codex"],
         capture_output=True, text=True, encoding="utf-8",
         errors="replace", cwd=str(tmp_path),
         env=_clean_subprocess_env(),
@@ -238,7 +239,7 @@ def test_setup_no_agent_no_file_shows_help(tmp_path):
     """No agent detected and no flags should show helpful guidance."""
     import subprocess
     result = subprocess.run(
-        ["python", "-m", "cartograph", "setup"],
+        [sys.executable, "-m", "cartograph", "setup"],
         capture_output=True, text=True, encoding="utf-8",
         errors="replace", cwd=str(tmp_path),
         env=_clean_subprocess_env(),
@@ -254,7 +255,7 @@ def test_setup_with_workflow(tmp_path):
     import subprocess
     os.makedirs(tmp_path / ".claude")
     result = subprocess.run(
-        ["python", "-m", "cartograph", "setup", "--workflow"],
+        [sys.executable, "-m", "cartograph", "setup", "--workflow"],
         capture_output=True, text=True, encoding="utf-8",
         errors="replace", cwd=str(tmp_path),
         env=_clean_subprocess_env(),
@@ -269,7 +270,7 @@ def test_setup_without_workflow_shows_tip(tmp_path):
     import subprocess
     os.makedirs(tmp_path / ".claude")
     result = subprocess.run(
-        ["python", "-m", "cartograph", "setup"],
+        [sys.executable, "-m", "cartograph", "setup"],
         capture_output=True, text=True, encoding="utf-8",
         errors="replace", cwd=str(tmp_path),
         env=_clean_subprocess_env(),
@@ -358,7 +359,7 @@ def test_setup_mcp_flag_writes_trimmed(tmp_path):
     import subprocess
     os.makedirs(tmp_path / ".claude")
     result = subprocess.run(
-        ["python", "-m", "cartograph", "setup", "--mcp"],
+        [sys.executable, "-m", "cartograph", "setup", "--mcp"],
         capture_output=True, text=True, encoding="utf-8",
         errors="replace", cwd=str(tmp_path),
         env=_clean_subprocess_env(),
@@ -379,7 +380,7 @@ def test_setup_autodetects_mcp_from_project_config(tmp_path):
     (tmp_path / ".mcp.json").write_text(
         json.dumps({"mcpServers": {"cartograph": {"command": "cartograph-mcp"}}}))
     result = subprocess.run(
-        ["python", "-m", "cartograph", "setup"],
+        [sys.executable, "-m", "cartograph", "setup"],
         capture_output=True, text=True, encoding="utf-8",
         errors="replace", cwd=str(tmp_path),
         env=_clean_subprocess_env(),
@@ -400,7 +401,7 @@ def test_setup_no_mcp_overrides_detection(tmp_path):
     (tmp_path / ".mcp.json").write_text(
         json.dumps({"mcpServers": {"cartograph": {"command": "cartograph-mcp"}}}))
     result = subprocess.run(
-        ["python", "-m", "cartograph", "setup", "--no-mcp"],
+        [sys.executable, "-m", "cartograph", "setup", "--no-mcp"],
         capture_output=True, text=True, encoding="utf-8",
         errors="replace", cwd=str(tmp_path),
         env=_clean_subprocess_env(),
@@ -416,7 +417,7 @@ def test_setup_mcp_with_workflow(tmp_path):
     import subprocess
     os.makedirs(tmp_path / ".claude")
     result = subprocess.run(
-        ["python", "-m", "cartograph", "setup", "--mcp", "--workflow"],
+        [sys.executable, "-m", "cartograph", "setup", "--mcp", "--workflow"],
         capture_output=True, text=True, encoding="utf-8",
         errors="replace", cwd=str(tmp_path),
         env=_clean_subprocess_env(),
@@ -436,11 +437,11 @@ def test_setup_overwrite_preserves_mcp_mode(tmp_path):
         json.dumps({"mcpServers": {"cartograph": {}}}))
     env = _clean_subprocess_env()
     subprocess.run(
-        ["python", "-m", "cartograph", "setup", "--workflow"],
+        [sys.executable, "-m", "cartograph", "setup", "--workflow"],
         capture_output=True, text=True, encoding="utf-8",
         errors="replace", cwd=str(tmp_path), env=env)
     result = subprocess.run(
-        ["python", "-m", "cartograph", "setup", "--overwrite"],
+        [sys.executable, "-m", "cartograph", "setup", "--overwrite"],
         capture_output=True, text=True, encoding="utf-8",
         errors="replace", cwd=str(tmp_path), env=env)
     assert result.returncode == 0


### PR DESCRIPTION
## macOS bug hunt

Ran the full suite and real CLI flows (create → validate → checkin → install → status) on the Mac mini node (macOS 26.5, arm64, python.org 3.14) in an ephemeral scratch env. Master showed **37 failures**; all traced to real bugs, fixed here.

### Bugs found and fixed

1. **AppleDouble / Finder cruft pollutes the library.** A binary `._module.py` resource fork in `src/` passed `validate`, was checked into the library (reproduced: it landed in the library copy), and would propagate to every consumer on install. A non-empty `.DS_Store` flipped an installed widget to `modified: true` because the implementation hash hashes every file. Fixes:
   - `universal-build-artifact-ignore-python` **v1.3.0**: new `is_os_metadata()` / `os_metadata_glob_patterns()` (`.DS_Store`, `._*`, `__MACOSX`, `Thumbs.db`, `desktop.ini`); `should_skip()` / `filter_dirs()` now always skip OS metadata.
   - Wired into: checkin copy + snapshot ignores, implementation hash, library diff, checkin modification report, contamination file walks, python engine source globs.

2. **macOS's no-JDK `java` stub defeats availability detection.** macOS ships `/usr/bin/java` even with no JDK; PATH resolution counted Java as available and the scanner died with Apple's "Unable to locate a Java Runtime" message (18 test failures). `JavaEngine.check_available()` now functionally probes `java -version` (cached per process) and reports an actionable JDK-install message. The contamination test skip helper probes the same way.

3. **`"python"` isn't a binary on macOS.** 19 tests spawned the CLI as `python -m cartograph` — `FileNotFoundError` on any default macOS/python.org install. Now `sys.executable`. Same fix applied to the `rules.py` template's subprocess example, which taught users the broken pattern.

4. **Unparseable `src/` files validated clean** (found while probing #1). A `.py` file in `src/` that doesn't parse was silently skipped by every AST check and never exercised by tests, yet `validate` passed. The python contamination scan now blocks with `src file <name> is not valid Python` (test files still just fail their own pytest run).

### Verification

- Full suite green on the Mac node (was 37 failures) — ephemeral use-then-toss scratch, cleaned on exit.
- End-to-end on macOS: doctor, create → validate → checkin → search → install → status, plus `.DS_Store` / `._*` regression scenarios.
- 8 new CLI regression tests + 6 new widget tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4Y61587L5cXmAZuEVWSFS
