### PR TITLE
fix: Windows bug hunt - readonly rmtree, hostile zip import, long-path errors

### DIFF
--- a/cg/universal_atomic_dir_swap_python/.validation_stamp.json
+++ b/cg/universal_atomic_dir_swap_python/.validation_stamp.json
@@ -1,0 +1,1 @@
+{"fingerprint": "0c19aef9cb2d268b8d833e153a0e8d37396d6bdc15dde2e6776bd93abbee9704", "stamped_at": "2026-07-08T17:37:58.461842+00:00", "language": "python", "engine_version": 1, "runtime": "python 3.14.6", "test_results": {}, "validated_at": "2026-07-08T17:37:58.461569+00:00"}

--- a/cg/universal_atomic_dir_swap_python/src/atomic_dir_swap.py
+++ b/cg/universal_atomic_dir_swap_python/src/atomic_dir_swap.py
@@ -21,11 +21,58 @@ containing exactly the staged contents, nothing from the previous version.
 
 import os
 import shutil
+import stat
+import sys
 import tempfile
 import uuid
 from contextlib import contextmanager
 
-__all__ = ["staged_dir", "atomic_swap_dir"]
+__all__ = ["staged_dir", "atomic_swap_dir", "robust_rmtree"]
+
+
+def _clear_readonly_and_retry(func, path, exc_info):
+    """``shutil.rmtree`` error handler: strip the read-only attribute and retry.
+
+    On Windows a read-only file makes ``os.unlink``/``os.rmdir`` raise
+    ``PermissionError`` (WinError 5), so a plain ``rmtree`` stops partway
+    through and leaves the tree half-deleted. POSIX deletes are governed by
+    the parent directory's permissions instead, so the handler also chmods
+    the parent when retrying the entry itself doesn't help.
+    """
+    del exc_info
+    try:
+        os.chmod(path, stat.S_IRWXU)
+        func(path)
+        return
+    except OSError:
+        pass
+    parent = os.path.dirname(path)
+    if parent:
+        os.chmod(parent, stat.S_IRWXU)
+    func(path)
+
+
+def robust_rmtree(path: str, ignore_errors: bool = False) -> None:
+    """``shutil.rmtree`` that survives read-only entries.
+
+    Drop-in replacement for the ``rmtree(path)`` / ``rmtree(path,
+    ignore_errors=True)`` call sites. Read-only files (the Windows attribute
+    or a POSIX mode with the write bit stripped) are made writable and
+    deleted instead of aborting mid-tree.
+    """
+    # ``onerror`` is deprecated since 3.12; ``onexc`` doesn't exist before it.
+    if sys.version_info >= (3, 12):
+        kwargs = {"onexc": lambda f, p, e: _clear_readonly_and_retry(f, p, None)}
+    else:
+        kwargs = {"onerror": _clear_readonly_and_retry}
+    try:
+        shutil.rmtree(path, **kwargs)
+    except FileNotFoundError:
+        if not ignore_errors:
+            raise
+    except OSError:
+        if not ignore_errors:
+            raise
 
 
 def atomic_swap_dir(new_dir: str, dest: str) -> None:
@@ -54,7 +101,7 @@ def atomic_swap_dir(new_dir: str, dest: str) -> None:
         raise
     finally:
         if backup is not None:
-            shutil.rmtree(backup, ignore_errors=True)
+            robust_rmtree(backup, ignore_errors=True)
 
 
 @contextmanager
@@ -72,7 +119,7 @@ def staged_dir(dest: str):
     try:
         yield tmp
     except BaseException:
-        shutil.rmtree(tmp, ignore_errors=True)
+        robust_rmtree(tmp, ignore_errors=True)
         raise
     else:
         try:
@@ -81,4 +128,4 @@ def staged_dir(dest: str):
             # On a successful swap, tmp was renamed into place; only a failed
             # swap leaves it behind.
             if os.path.isdir(tmp):
-                shutil.rmtree(tmp, ignore_errors=True)
+                robust_rmtree(tmp, ignore_errors=True)

--- a/cg/universal_atomic_dir_swap_python/tests/test_atomic_dir_swap.py
+++ b/cg/universal_atomic_dir_swap_python/tests/test_atomic_dir_swap.py
@@ -97,3 +97,48 @@ def test_no_leftover_backup_dirs(tmp_path):
         with open(os.path.join(tmp, "y"), "w") as f:
             f.write("2")
     assert not any(p.name.startswith(".cg-old-") for p in tmp_path.iterdir())
+
+
+def _make_readonly_tree(tmp_path):
+    tree = tmp_path / "victim"
+    (tree / "sub").mkdir(parents=True)
+    locked = tree / "sub" / "locked.txt"
+    locked.write_text("keep out")
+    os.chmod(locked, 0o444)
+    if os.name == "nt":
+        import stat as _stat
+        os.chmod(locked, _stat.S_IREAD)
+    return tree
+
+
+def test_robust_rmtree_removes_readonly_entries(tmp_path):
+    from src.atomic_dir_swap import robust_rmtree
+    tree = _make_readonly_tree(tmp_path)
+    robust_rmtree(str(tree))
+    assert not tree.exists()
+
+
+def test_robust_rmtree_missing_path_raises_by_default(tmp_path):
+    from src.atomic_dir_swap import robust_rmtree
+    with pytest.raises(FileNotFoundError):
+        robust_rmtree(str(tmp_path / "nope"))
+
+
+def test_robust_rmtree_missing_path_ignored_when_asked(tmp_path):
+    from src.atomic_dir_swap import robust_rmtree
+    robust_rmtree(str(tmp_path / "nope"), ignore_errors=True)
+
+
+def test_robust_rmtree_readonly_dir_entries(tmp_path):
+    from src.atomic_dir_swap import robust_rmtree
+    tree = tmp_path / "victim2"
+    inner = tree / "inner"
+    inner.mkdir(parents=True)
+    (inner / "f.txt").write_text("x")
+    os.chmod(inner, 0o555)
+    try:
+        robust_rmtree(str(tree))
+    finally:
+        if inner.exists():
+            os.chmod(inner, 0o755)
+    assert not tree.exists()

--- a/cg/universal_atomic_dir_swap_python/widget.json
+++ b/cg/universal_atomic_dir_swap_python/widget.json
@@ -2,7 +2,7 @@
   "meta": {
     "id": "universal-atomic-dir-swap-python",
     "name": "Atomic Dir Swap",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "domain": "universal",
     "tags": [
       "atomic",
@@ -25,7 +25,7 @@
   },
   "validation": {
     "engine_version": 1,
-    "validated_at": "2026-06-25T18:44:10.872490+00:00",
-    "runtime": "python 3.14.5"
+    "validated_at": "2026-07-08T17:37:58.964374+00:00",
+    "runtime": "python 3.14.6"
   }
 }

--- a/src/cartograph/blueprint_checkin.py
+++ b/src/cartograph/blueprint_checkin.py
@@ -17,6 +17,7 @@ import json
 import logging
 import os
 import shutil
+from .safefs import robust_rmtree
 
 from .languages import get_engine
 from .validation_stamp import has_valid_stamp, write_stamp
@@ -212,7 +213,7 @@ def checkin_blueprint(carto, path: str, reason: str = "", version_bump: str = "m
     if is_update:
         history_path = os.path.join(dest_path, "history", baseline_version or "unknown")
         if os.path.exists(history_path):
-            shutil.rmtree(history_path)
+            robust_rmtree(history_path)
         os.makedirs(history_path, exist_ok=True)
         ignore = shutil.ignore_patterns(
             ".venv", "__pycache__", ".pytest_cache", "*.pyc",
@@ -248,7 +249,7 @@ def checkin_blueprint(carto, path: str, reason: str = "", version_bump: str = "m
         dst = os.path.join(dest_path, item)
         if os.path.isdir(src):
             if os.path.exists(dst):
-                shutil.rmtree(dst)
+                robust_rmtree(dst)
             shutil.copytree(src, dst, ignore=ignore)
         else:
             shutil.copy2(src, dst)

--- a/src/cartograph/blueprint_install.py
+++ b/src/cartograph/blueprint_install.py
@@ -16,6 +16,7 @@ Override semantics (newer-pin wins):
 import json
 import os
 import shutil
+from .safefs import robust_rmtree
 
 from .blueprints import is_blueprint_id
 
@@ -341,4 +342,4 @@ def _rollback(carto, target_dir, leaf_changes, placed_blueprint, bp_dest):
         except Exception:
             pass
     if placed_blueprint and os.path.isdir(bp_dest):
-        shutil.rmtree(bp_dest, ignore_errors=True)
+        robust_rmtree(bp_dest, ignore_errors=True)

--- a/src/cartograph/checkin.py
+++ b/src/cartograph/checkin.py
@@ -30,7 +30,7 @@ import shutil
 
 from .engine import semver_key as _semver_key, _is_os_metadata
 from .languages import get_engine
-from .safefs import widget_lock, staged_dir, LockTimeout
+from .safefs import widget_lock, staged_dir, robust_rmtree, LockTimeout
 from .scaffolding import _library_notes as _canonical_library_notes
 from .validation_stamp import is_stamp_valid, write_stamp, STAMP_FILE as _STAMP_FILE
 from .dep_cache import DEP_STAMP_FILE as _DEP_STAMP_FILE
@@ -492,7 +492,7 @@ def checkin(carto, path: str, reason: str = "", version_bump: str = "minor",
                     old_version = widget_record.get("version", "unknown")
                     snap = os.path.join(staged, "history", old_version)
                     if os.path.exists(snap):
-                        shutil.rmtree(snap)
+                        robust_rmtree(snap)
                     os.makedirs(snap, exist_ok=True)
                     for item in os.listdir(dest_path):
                         if item in carry_skips:
@@ -595,7 +595,7 @@ def restore(carto, item_id, version, reason):
     # Copy history version to a temp dir, then checkin as update
     import tempfile
     temp_dir = tempfile.mkdtemp(prefix=f"cartograph_restore_{item_id}_")
-    shutil.rmtree(temp_dir)  # mkdtemp creates it, copytree needs it to not exist
+    robust_rmtree(temp_dir)  # mkdtemp creates it, copytree needs it to not exist
     shutil.copytree(history_path, temp_dir)
 
     # Set manifest version to current library version so the version guard
@@ -610,7 +610,7 @@ def restore(carto, item_id, version, reason):
 
     result = checkin(carto, temp_dir, reason=f"RESTORE from v{version}: {reason}",
                      version_bump="patch")
-    shutil.rmtree(temp_dir, ignore_errors=True)
+    robust_rmtree(temp_dir, ignore_errors=True)
     return result
 
 

--- a/src/cartograph/cli.py
+++ b/src/cartograph/cli.py
@@ -2723,6 +2723,16 @@ def cmd_import(args):
     from .engine import LIBRARY_PATH
     from .safefs import assert_members_safe, UnsafeArchiveError, widget_lock, LockTimeout
 
+    try:
+        from cg.universal_build_artifact_ignore_python.src.build_artifact_ignore import (
+            is_os_metadata as _is_os_metadata,
+        )
+    except ImportError:  # partial install - keep the gate working regardless
+        def _is_os_metadata(name):
+            base = os.path.basename(name.rstrip("/\\"))
+            return (base in {".DS_Store", "__MACOSX", "Thumbs.db", "desktop.ini"}
+                    or base.startswith("._"))
+
     path = args.path
     if not os.path.isfile(path):
         err({"error": f"File not found: {path}"})
@@ -2743,7 +2753,22 @@ def cmd_import(args):
     gate_results = ([], [], [])
     try:
         with zipfile.ZipFile(path, "r") as zf:
-            names = zf.namelist()
+            # Normalize separators up front: zips written by tools like
+            # PowerShell 5.1's Compress-Archive use backslashes, which only
+            # "work" on Windows by accident (os.path treats them as
+            # separators) and scatter literal-backslash filenames on POSIX.
+            # Everything below operates on the normalized name; the original
+            # is kept only as the zf.open() key.
+            members = [(n, n.replace("\\", "/")) for n in zf.namelist()]
+            # Drop OS-scattered metadata (__MACOSX/, AppleDouble ._*,
+            # Thumbs.db, .DS_Store, desktop.ini) before it can become a
+            # phantom library dir or ride into a widget's files.
+            members = [
+                (orig, norm) for orig, norm in members
+                if not any(_is_os_metadata(part)
+                           for part in norm.split("/") if part)
+            ]
+            names = [norm for _, norm in members]
             manifests = [n for n in names if n.endswith("widget.json") and n.count("/") == 1]
             if not manifests:
                 err({"error": "Zip does not appear to contain a widget library (no widget.json files found)."})
@@ -2755,29 +2780,41 @@ def cmd_import(args):
             # and gated under its OWN lock - importing widget A doesn't block a
             # concurrent checkin of widget B, only of widget A.
             by_widget = {}
-            for name in names:
-                head = name.split("/", 1)[0]
+            for orig, norm in members:
+                head = norm.split("/", 1)[0]
                 if head:
-                    by_widget.setdefault(head, []).append(name)
+                    by_widget.setdefault(head, []).append((orig, norm))
 
             carto = _carto()
             force = getattr(args, "force", False)
             accepted_stamped, accepted_revalidated, quarantined = [], [], []
-            for head, members in sorted(by_widget.items()):
+            for head, widget_members in sorted(by_widget.items()):
+                # Widget ids are lowercase slugs by construction. A mixed-case
+                # dir would silently merge into an existing entry on a
+                # case-insensitive filesystem (NTFS/APFS), letting a crafted
+                # zip rename or overwrite a widget it doesn't name.
+                if head != head.lower():
+                    quarantined.append({
+                        "id": head,
+                        "reason": "rejected: widget directory is not a "
+                                  "lowercase slug (case-insensitive filesystems "
+                                  "would merge it into another entry)",
+                    })
+                    continue
                 with widget_lock(LIBRARY_PATH, head):
-                    for name in members:
-                        dest = os.path.join(LIBRARY_PATH, name)
-                        if name.endswith("/"):
+                    for orig, norm in widget_members:
+                        dest = os.path.join(LIBRARY_PATH, *norm.split("/"))
+                        if norm.endswith("/"):
                             os.makedirs(dest, exist_ok=True)
                             continue
                         if os.path.exists(dest) and not force:
                             skipped += 1
                             continue
                         os.makedirs(os.path.dirname(dest), exist_ok=True)
-                        with zf.open(name) as src, open(dest, "wb") as dst:
+                        with zf.open(orig) as src, open(dest, "wb") as dst:
                             dst.write(src.read())
                         imported += 1
-                        if "/" in name:
+                        if "/" in norm:
                             imported_widget_ids.add(head)
                     # Gate THIS widget under its lock.
                     if head in imported_widget_ids:
@@ -2838,6 +2875,11 @@ def _gate_one_widget(carto, wid_dir, LIBRARY_PATH, quarantine_dir,
         reason = result.get("message", "validation failed")
         _quarantine_widget(widget_path, quarantine_dir, reason)
         return "quarantined", {"id": wid_dir, "reason": reason}
+    # Validation ran IN the library dir (unlike checkin, which validates the
+    # working copy and filters artifacts during the copy), so scrub the
+    # artifacts it left behind - a .venv alone is thousands of files that
+    # would otherwise live in the library and flow to consumers.
+    _clean_validation_artifacts(widget_path, language)
     try:
         write_stamp(widget_path, language, engine, test_results=None)
         return "revalidated", wid_dir
@@ -2864,6 +2906,37 @@ def _import_summary(imported, imported_widget_ids, quarantine_dir, skipped,
     if skipped:
         print(f"    skipped (already exist, no --force): {skipped}")
     print()
+
+
+def _clean_validation_artifacts(widget_path: str, language: str) -> None:
+    """Remove build/validation artifacts from a library widget dir in place.
+
+    Mirrors the artifact filter checkin applies when copying into the
+    library; import's re-validation gate is the one path that validates
+    directly inside the library entry.
+    """
+    from .safefs import robust_rmtree
+    from .dep_cache import DEP_STAMP_FILE
+    try:
+        from cg.universal_build_artifact_ignore_python.src.build_artifact_ignore import (
+            excludes_for,
+        )
+        skip_names = set(excludes_for(language=language))
+    except ImportError:
+        skip_names = {"__pycache__", ".pytest_cache", ".venv", "node_modules",
+                      ".coverage", "coverage"}
+    skip_names |= {".coverage", DEP_STAMP_FILE}
+    for root, dirs, files in os.walk(widget_path, topdown=True):
+        for d in list(dirs):
+            if d in skip_names:
+                robust_rmtree(os.path.join(root, d), ignore_errors=True)
+                dirs.remove(d)
+        for f in files:
+            if f in skip_names:
+                try:
+                    os.remove(os.path.join(root, f))
+                except OSError:
+                    pass
 
 
 def _quarantine_widget(widget_path: str, quarantine_dir: str, reason: str) -> None:

--- a/src/cartograph/installer.py
+++ b/src/cartograph/installer.py
@@ -7,14 +7,39 @@ import json
 import os
 import re
 import shutil
+from .safefs import robust_rmtree
 import zipfile
 from io import BytesIO
+
+
+def _long_path_error(e, dest_path):
+    """Turn Windows' bare WinError 3/206 into an actionable message when the
+    real problem is the 260-char MAX_PATH default. Returns None otherwise."""
+    if (os.name == "nt" and isinstance(e, OSError)
+            and getattr(e, "winerror", None) in (3, 206)
+            and len(dest_path) > 200):
+        return {"error": (
+            f"Install path is likely too long for Windows "
+            f"({len(dest_path)}+ chars): {dest_path}. Windows limits paths "
+            f"to 260 characters by default. Install into a shorter target "
+            f"path, or enable long paths (set the LongPathsEnabled registry "
+            f"value to 1) and retry."
+        )}
+    return None
 
 
 def _copy_widget(source_path, dest_path):
     """Copy widget files from library to destination."""
     os.makedirs(dest_path, exist_ok=True)
-    ignore = shutil.ignore_patterns("__pycache__", "*.pyc", ".pytest_cache")
+    try:
+        from cg.universal_build_artifact_ignore_python.src.build_artifact_ignore import (
+            os_metadata_glob_patterns,
+        )
+        os_junk = os_metadata_glob_patterns()
+    except ImportError:
+        os_junk = (".DS_Store", "._*", "__MACOSX", "Thumbs.db", "desktop.ini")
+    ignore = shutil.ignore_patterns("__pycache__", "*.pyc", ".pytest_cache",
+                                    *os_junk)
 
     for folder in ("src", "tests", "examples"):
         src = os.path.join(source_path, folder)
@@ -143,8 +168,8 @@ def _install_from_cloud(widget_id, dest_path, registry_url=None, owner_hint=None
         }
     except Exception as e:
         # Clean up partial install
-        shutil.rmtree(dest_path, ignore_errors=True)
-        return {"error": f"Failed to extract widget: {e}"}
+        robust_rmtree(dest_path, ignore_errors=True)
+        return _long_path_error(e, dest_path) or {"error": f"Failed to extract widget: {e}"}
 
 
 def install(carto, widget_id, target_dir, version=None,
@@ -251,7 +276,7 @@ def install(carto, widget_id, target_dir, version=None,
                 "installed_at": dest_path,
             }
         except Exception as e:
-            return {"error": str(e)}
+            return _long_path_error(e, dest_path) or {"error": str(e)}
 
     # Fall back to cloud registry if enabled
     from .config import cloud_enabled
@@ -296,7 +321,7 @@ def upgrade(carto, widget_id, target_dir, version=None):
     backup_path = _upgrade_backup_path(widget_id)
     try:
         if os.path.exists(backup_path):
-            shutil.rmtree(backup_path)
+            robust_rmtree(backup_path)
         shutil.copytree(dest_path, backup_path)
     except Exception as e:
         return {"error": f"Could not create upgrade backup: {e}"}
@@ -304,7 +329,7 @@ def upgrade(carto, widget_id, target_dir, version=None):
     # Remove old copy
     result = uninstall(carto, widget_id, target_dir)
     if "error" in result:
-        shutil.rmtree(backup_path, ignore_errors=True)
+        robust_rmtree(backup_path, ignore_errors=True)
         return result
 
     # Install new copy — pass owner and registry from sidecar so we upgrade
@@ -323,11 +348,11 @@ def upgrade(carto, widget_id, target_dir, version=None):
         else:
             result["restored"] = True
             result["restored_version"] = old_version
-        shutil.rmtree(backup_path, ignore_errors=True)
+        robust_rmtree(backup_path, ignore_errors=True)
         return result
 
     # Success — clean up backup
-    shutil.rmtree(backup_path, ignore_errors=True)
+    robust_rmtree(backup_path, ignore_errors=True)
     result["previous_version"] = old_version
     return result
 
@@ -354,7 +379,7 @@ def delete_from_library(carto, widget_id, confirm=False):
     from .safefs import widget_lock, LockTimeout
     try:
         with widget_lock(carto.library_path, widget_id):
-            shutil.rmtree(widget_path)
+            robust_rmtree(widget_path)
     except LockTimeout as e:
         return {"error": str(e)}
     except Exception as e:
@@ -394,7 +419,7 @@ def uninstall(carto, widget_id, target_dir):
         return {"error": f"Safety check failed: path escapes target directory."}
 
     try:
-        shutil.rmtree(widget_path)
+        robust_rmtree(widget_path)
         return {"status": "success", "widget_id": widget_id, "removed_from": widget_path}
     except Exception as e:
         return {"error": f"Failed to remove: {e}"}

--- a/src/cartograph/safefs.py
+++ b/src/cartograph/safefs.py
@@ -23,6 +23,7 @@ from cg.infra_interprocess_lock_python.src.interprocess_lock import (
 from cg.universal_atomic_dir_swap_python.src.atomic_dir_swap import (
     staged_dir,
     atomic_swap_dir,
+    robust_rmtree,
 )
 from cg.universal_safe_archive_extract_python.src.safe_archive_extract import (
     safe_extractall,
@@ -38,6 +39,7 @@ __all__ = [
     "UnsafeArchiveError",
     "staged_dir",
     "atomic_swap_dir",
+    "robust_rmtree",
     "widget_lock",
     "library_lock",
     "LockTimeout",

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,179 @@
+"""cartograph import: hostile-zip handling.
+
+Covers the Windows bug-hunt findings: backslash-separator zips (PowerShell
+5.1 Compress-Archive), OS-metadata entries (__MACOSX/, AppleDouble ._*,
+Thumbs.db), mixed-case widget dirs that would merge into an existing entry
+on a case-insensitive filesystem, and validation artifacts left inside the
+library entry by import's re-validation gate.
+"""
+import json
+import os
+import zipfile
+from types import SimpleNamespace
+
+import pytest
+
+from tests.conftest import _make_widget
+
+_SRC = '''def add(a, b):
+    """Add two numbers."""
+    return a + b
+'''
+
+_TEST = '''import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+from adder import add
+
+
+def test_add():
+    assert add(1, 2) == 3
+'''
+
+_EXAMPLE = '''import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+from adder import add
+
+result = add(2, 2)
+'''
+
+
+def _build_widget(base, widget_id="universal-adder-python"):
+    return _make_widget(
+        base, widget_id, "Adder", "1.0.0", "universal", "python",
+        ["math"], "Adds numbers", [], "adder.py", _SRC, _TEST, _EXAMPLE,
+    )
+
+
+def _zip_dir(src_root, zip_path, name_fn=lambda n: n, extra=()):
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        for root, _dirs, files in os.walk(src_root):
+            for f in files:
+                full = os.path.join(root, f)
+                rel = os.path.relpath(full, src_root).replace(os.sep, "/")
+                with open(full, "rb") as fh:
+                    zf.writestr(name_fn(rel), fh.read())
+        for name, data in extra:
+            zf.writestr(name, data)
+
+
+@pytest.fixture
+def import_env(tmp_path, monkeypatch):
+    """Point the CLI's library at a fresh temp dir and return paths."""
+    lib = tmp_path / "Widget_Library"
+    lib.mkdir()
+    import cartograph.engine as engine
+    monkeypatch.setattr(engine, "LIBRARY_PATH", str(lib))
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    return SimpleNamespace(lib=str(lib), staging=str(staging),
+                           tmp=str(tmp_path))
+
+
+def _run_import(zip_path, force=False):
+    from cartograph.cli import cmd_import
+    return cmd_import(SimpleNamespace(path=str(zip_path), force=force))
+
+
+def test_import_accepts_forward_slash_zip(import_env):
+    _build_widget(import_env.staging)
+    zp = os.path.join(import_env.tmp, "lib.zip")
+    _zip_dir(import_env.staging, zp)
+    _run_import(zp)
+    dest = os.path.join(import_env.lib, "universal-adder-python")
+    assert os.path.isfile(os.path.join(dest, "widget.json"))
+    assert os.path.isfile(os.path.join(dest, "src", "adder.py"))
+
+
+def test_import_normalizes_backslash_zip(import_env):
+    """Compress-Archive-style zips use backslash separators; they must land
+    as nested dirs on every OS, not as literal-backslash filenames."""
+    _build_widget(import_env.staging)
+    zp = os.path.join(import_env.tmp, "bs.zip")
+    _zip_dir(import_env.staging, zp, name_fn=lambda n: n.replace("/", "\\"))
+    _run_import(zp)
+    dest = os.path.join(import_env.lib, "universal-adder-python")
+    assert os.path.isfile(os.path.join(dest, "src", "adder.py"))
+    # No literal-backslash spill anywhere in the library
+    assert not [n for n in os.listdir(import_env.lib) if "\\" in n]
+
+
+def test_import_skips_os_metadata_entries(import_env):
+    """__MACOSX/, AppleDouble ._*, Thumbs.db and .DS_Store never reach the
+    library - neither as phantom top-level dirs nor inside the widget."""
+    _build_widget(import_env.staging)
+    zp = os.path.join(import_env.tmp, "junk.zip")
+    junk = [
+        ("__MACOSX/universal-adder-python/._widget.json", b"\x00\x05\x16\x07"),
+        ("universal-adder-python/src/._adder.py", b"\x00\x05\x16\x07"),
+        ("universal-adder-python/Thumbs.db", b"junk"),
+        ("universal-adder-python/.DS_Store", b"\x00junk"),
+    ]
+    _zip_dir(import_env.staging, zp, extra=junk)
+    _run_import(zp)
+    dest = os.path.join(import_env.lib, "universal-adder-python")
+    assert os.path.isfile(os.path.join(dest, "src", "adder.py"))
+    assert not os.path.exists(os.path.join(import_env.lib, "__MACOSX"))
+    assert not os.path.exists(os.path.join(dest, "Thumbs.db"))
+    assert not os.path.exists(os.path.join(dest, ".DS_Store"))
+    assert not os.path.exists(os.path.join(dest, "src", "._adder.py"))
+    # And no lock file was minted for the junk dir
+    locks = os.listdir(os.path.join(import_env.lib, ".locks"))
+    assert not [l for l in locks if "__MACOSX" in l]
+
+
+def test_import_rejects_mixed_case_widget_dir(import_env, capsys):
+    """A widget dir that isn't a lowercase slug is rejected: on NTFS/APFS it
+    would silently merge into (and effectively rename) an existing entry."""
+    _build_widget(import_env.staging)
+    zp = os.path.join(import_env.tmp, "case.zip")
+    _zip_dir(import_env.staging, zp,
+             name_fn=lambda n: n.replace("adder", "ADDER"))
+    _run_import(zp)
+    out = capsys.readouterr().out
+    assert "lowercase" in out
+    assert not os.path.exists(
+        os.path.join(import_env.lib, "universal-ADDER-python"))
+
+
+def test_import_rejects_mixed_case_alongside_valid(import_env, capsys):
+    _build_widget(import_env.staging)
+    zp = os.path.join(import_env.tmp, "case2.zip")
+    with zipfile.ZipFile(zp, "w") as zf:
+        for root, _dirs, files in os.walk(import_env.staging):
+            for f in files:
+                full = os.path.join(root, f)
+                rel = os.path.relpath(full, import_env.staging).replace(os.sep, "/")
+                with open(full, "rb") as fh:
+                    data = fh.read()
+                zf.writestr(rel, data)
+                zf.writestr(rel.replace("adder", "ADDER"), data)
+    _run_import(zp)
+    out = capsys.readouterr().out
+    assert os.path.isfile(os.path.join(
+        import_env.lib, "universal-adder-python", "src", "adder.py"))
+    # Exact-name check: os.path.exists would match the lowercase dir on a
+    # case-insensitive filesystem.
+    assert "universal-ADDER-python" not in os.listdir(import_env.lib)
+    assert "lowercase" in out
+
+
+def test_clean_validation_artifacts(tmp_path):
+    """Import's in-place re-validation must not leave .venv/.coverage/dep
+    cache/__pycache__ inside the library entry."""
+    from cartograph.cli import _clean_validation_artifacts
+    w = tmp_path / "widget"
+    (w / ".venv" / "Lib").mkdir(parents=True)
+    (w / ".venv" / "Lib" / "site.py").write_text("x")
+    (w / "src" / "__pycache__").mkdir(parents=True)
+    (w / "src" / "__pycache__" / "m.pyc").write_text("x")
+    (w / "src" / "mod.py").write_text("def f():\n    return 1\n")
+    (w / ".coverage").write_text("data")
+    (w / ".dep_cache.json").write_text("{}")
+    (w / "widget.json").write_text("{}")
+    _clean_validation_artifacts(str(w), "python")
+    assert not (w / ".venv").exists()
+    assert not (w / ".coverage").exists()
+    assert not (w / ".dep_cache.json").exists()
+    assert not (w / "src" / "__pycache__").exists()
+    assert (w / "src" / "mod.py").exists()
+    assert (w / "widget.json").exists()


### PR DESCRIPTION
Windows run of the OS bug hunt (method per the macOS run, PR #38). Notably, the full suite was already green on Windows - every bug below was found only by exercising the CLI as a real user on the Windows node, then reproduced and fixed.

## Bugs found and fixed

**1. Read-only files break every destructive operation (Windows)**
A single read-only file (`attrib +R`, common from source control / copied media) made `uninstall` and `delete` fail with WinError 5, and `upgrade` abort partway: it left a half-deleted, corrupted install (`modified: true`, files missing). A dozen `ignore_errors=True` rmtree sites also silently leaked (stale upgrade backups, temp dirs).
Fix at the widget layer: `universal-atomic-dir-swap-python` v1.1.0 adds `robust_rmtree` (clears the readonly bit and retries; `onexc` on 3.12+, `onerror` below), used internally and re-exported via the safefs seam. All destructive CLI sites (installer, checkin, blueprint checkin/install) now use it.

**2. `cartograph import` trusted hostile/dirty zips**
- `__MACOSX/` from a Finder zip became a phantom top-level library dir (plus its own `.locks` entry); AppleDouble `._*`, `Thumbs.db`, `.DS_Store` rode into the widget dir and would propagate to consumers. Entries whose path contains an OS-metadata segment are now skipped (sourced from `universal-build-artifact-ignore-python`).
- Backslash-separator zips (PowerShell 5.1 `Compress-Archive` writes these) only worked on Windows by accident and would scatter literal-`\` filenames on Linux. Entry names are now normalized before grouping/manifest detection/zip-slip checks.
- A widget dir differing from an existing entry only by case silently merged into it on NTFS/APFS - a crafted zip could effectively rename/hijack a widget id. Non-lowercase widget dirs are now rejected loudly.
- Import's in-place re-validation left a full `.venv`, `.coverage`, and `.dep_cache.json` inside the library entry (cross-platform bug). Artifacts are now scrubbed after the gate, mirroring checkin's copy filter.

**3. MAX_PATH failures were inscrutable**
Install into a ~250-char target died with a bare `[WinError 3]`. Now surfaced as an actionable error (shorten the target or enable `LongPathsEnabled`). Full long-path support deliberately not attempted.

Also: library→project copies now filter OS metadata (defense in depth on top of #38).

## Verified clean on the node (no fix needed)
`Thumbs.db`/`desktop.ini` vs the implementation hash (the #38 filter works on real Windows-produced files), NTFS `Zone.Identifier` ADS, unicode round-trip (em dash/✓ in descriptions on the Windows console), export zip entry names, backslash paths as CLI args.

## Validation
- Windows node (fresh clone, fresh venv, isolated profile): **810 passed / 0 failed**, up from 804 baseline (new tests)
- Every bug reproduced on the node before the fix and re-probed green after: readonly uninstall/upgrade, all three hostile zips, MAX_PATH message
- New `tests/test_import.py` (6 tests) + 4 `robust_rmtree` widget tests
- Note: `universal-atomic-dir-swap-python` v1.1.0 is checked into the local library but unpublished (box not authenticated) - same situation as the ignore widget's v1.3.0 from #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4Y61587L5cXmAZuEVWSFS