### PR TITLE
fix: allowed_extensions() must cover engine-owned manifest files (.gradle)

### DIFF
--- a/src/cartograph/languages/registry.py
+++ b/src/cartograph/languages/registry.py
@@ -83,5 +83,15 @@ def available_languages() -> set[str]:
 def allowed_extensions() -> set[str]:
     """Return all file extensions used by registered language engines.
     Used by the cloud registry to validate widget zip contents — automatically
-    includes any new language without cloud-side changes."""
-    return {engine.file_ext for engine in _ENGINES.values() if engine.file_ext}
+    includes any new language without cloud-side changes.
+
+    Covers each engine's source extension plus the extensions of its
+    engine-owned manifest files (manifest_patterns), so build files like
+    Java's build.gradle are accepted by the cloud zip validator."""
+    exts = {engine.file_ext for engine in _ENGINES.values() if engine.file_ext}
+    for engine in _ENGINES.values():
+        for pattern in engine.manifest_patterns:
+            ext = os.path.splitext(pattern)[1].lstrip(".")
+            if ext:
+                exts.add(ext)
+    return exts

--- a/tests/test_language_engines.py
+++ b/tests/test_language_engines.py
@@ -37,6 +37,20 @@ def test_supported_languages():
     assert "systemverilog" in langs
 
 
+def test_allowed_extensions_includes_source_exts():
+    from cartograph.languages.registry import allowed_extensions
+    exts = allowed_extensions()
+    assert "py" in exts
+    assert "java" in exts
+
+
+def test_allowed_extensions_includes_manifest_exts():
+    # Engine-owned build files (Java's build.gradle) must be accepted by
+    # the cloud zip validator, which builds its whitelist from this seam.
+    from cartograph.languages.registry import allowed_extensions
+    assert "gradle" in allowed_extensions()
+
+
 def test_python_engine_run_tests_pass(tmp_path):
     from cartograph.languages.python import PythonEngine
     # Create a minimal passing widget


### PR DESCRIPTION
Cloud publish rejects every Java widget: the zip validator whitelist is built from `allowed_extensions()`, which only collected each engine's `file_ext` (`java`), while Java widgets necessarily carry `build.gradle`/`settings.gradle` (the engine design says widgets own their build file).

Fix: `allowed_extensions()` now also includes the extensions of each engine's `manifest_patterns`, so `.gradle` flows through automatically - and so does any future engine's build file, with no cloud-side change.

A companion cartograph-cloud PR adds `.gradle` to the static belt-and-suspenders list so the cloud is unblocked before this rides a CLI release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)