### PR TITLE
Release 0.7.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cartograph-cli"
-version = "0.7.15"
+version = "0.7.16"
 description = "Widget library manager for AI agents — CLI"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump to ship the fixes merged since v0.7.15:

- #35 publish chain silently skipping fresh-install/release on the auto-tag dispatch path (this release is also that fix's first live verification)
- #36 doctor: stop npx downloading playwright just to report its absence
- #37 setup: MCP mode with trimmed instructions
- #38 macOS bug hunt: OS-metadata filtering, java stub detection, python-on-PATH portability
- #39 Windows bug hunt: readonly rmtree, hostile zip import, long-path errors
- #40 allowed_extensions() covers engine manifest files (.gradle)

After PyPI is live, follow up with the cartograph-cloud pinned-CLI bump + redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)