### PR TITLE
Registry-mediated token refresh + one-time-code login (0.7.17)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cartograph-cli"
-version = "0.7.16"
+version = "0.7.17"
 description = "Widget library manager for AI agents — CLI"
 readme = "README.md"
 license = "MIT"

--- a/src/cartograph/auth.py
+++ b/src/cartograph/auth.py
@@ -125,11 +125,11 @@ def _is_token_expired(token: str) -> bool:
 
 
 def _refresh_id_token(refresh_token: str) -> str | None:
-    """Use a refresh token to get a new ID token from the identity provider.
+    """Use a refresh token to get a new ID token.
 
-    The token endpoint comes from stored credentials (handed back by the
-    registry at login - any OIDC issuer), falling back to Google for
-    credentials saved before token_url existed.
+    Preferred path: POST JSON to the Cartograph registry ``/v1/auth/refresh``
+    so the OAuth client secret never lives on the workstation. Legacy path:
+    form-POST to a stored IdP token_url with client_id/secret (old logins).
 
     Returns the new id_token, or None on failure.
     """
@@ -137,37 +137,64 @@ def _refresh_id_token(refresh_token: str) -> str | None:
         return None
 
     creds = _read_credentials()
-    token_url = creds.get("token_url") or _GOOGLE_TOKEN_URL
-    if not token_url.startswith("https://"):
-        log.debug("Refusing token refresh against non-https endpoint")
-        return None
+    token_url = (creds.get("token_url") or "").strip()
+    registry = get_registry_url().rstrip("/")
+    # New logins point token_url at the registry refresh endpoint. If empty
+    # or missing a client secret, always go through the registry.
+    use_registry = (
+        not token_url
+        or token_url.rstrip("/").endswith("/v1/auth/refresh")
+        or not _google_client_secret()
+    )
+    if use_registry:
+        refresh_url = (
+            token_url if token_url.rstrip("/").endswith("/v1/auth/refresh")
+            else f"{registry}/v1/auth/refresh"
+        )
+        if not refresh_url.startswith("https://") and not refresh_url.startswith("http://127.0.0.1"):
+            log.debug("Refusing token refresh against non-https endpoint")
+            return None
+        body = json.dumps({"refresh_token": refresh_token}).encode()
+        req = urllib.request.Request(
+            refresh_url, data=body, method="POST",
+            headers={"Content-Type": "application/json", "Accept": "application/json"},
+        )
+    else:
+        # Legacy: direct IdP refresh with secrets stored from an older login.
+        if not token_url.startswith("https://"):
+            token_url = _GOOGLE_TOKEN_URL
+        client_id = _google_client_id()
+        client_secret = _google_client_secret()
+        if not client_id:
+            log.debug("Cannot refresh token: no client_id stored")
+            return None
+        form = {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": client_id,
+        }
+        if client_secret:
+            form["client_secret"] = client_secret
+        req = urllib.request.Request(
+            token_url,
+            data=urllib.parse.urlencode(form).encode(),
+            method="POST",
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
 
-    # Need client_id (and usually client_secret) for refresh
-    client_id = _google_client_id()
-    client_secret = _google_client_secret()
-    if not client_id:
-        log.debug("Cannot refresh token: no client_id stored")
-        return None
-
-    form = {
-        "grant_type": "refresh_token",
-        "refresh_token": refresh_token,
-        "client_id": client_id,
-    }
-    if client_secret:  # public OIDC clients have no secret
-        form["client_secret"] = client_secret
-    data = urllib.parse.urlencode(form).encode()
-
-    req = urllib.request.Request(token_url, data=data, method="POST")
     try:
         from .net_tls import registry_ssl_context
         with urllib.request.urlopen(req, timeout=10, context=registry_ssl_context()) as resp:
             result = json.loads(resp.read())
         new_id_token = result.get("id_token")
         if new_id_token:
-            # Update stored credentials with new id_token
             creds = _read_credentials()
             creds["id_token"] = new_id_token
+            # Drop any legacy secret once registry-mediated refresh works.
+            if use_registry:
+                creds.pop("client_secret", None)
+                if not creds.get("token_url"):
+                    creds["token_url"] = f"{registry}/v1/auth/refresh"
             _write_credentials(creds)
             log.debug("ID token refreshed successfully")
             return new_id_token

--- a/src/cartograph/cli.py
+++ b/src/cartograph/cli.py
@@ -1455,10 +1455,38 @@ def cmd_login(args):
         err({"error": "Provide a token with --token or set CARTOGRAPH_TOKEN"})
 
     import http.server
+    import json as _json
     import webbrowser
     from .auth import get_registry_url, save_credentials
 
     received = {}
+
+    _SUCCESS_HTML = (
+        b"<!DOCTYPE html><html><head><meta charset=utf-8>"
+        b"<meta name=viewport content=\"width=device-width, initial-scale=1\">"
+        b"<title>Cartograph - signed in</title>"
+        b"<style>"
+        b"body{font-family:ui-sans-serif,system-ui,sans-serif;max-width:28rem;"
+        b"margin:4rem auto;padding:0 1.25rem;background:#14161C;color:#E8E6E3}"
+        b"h1{font-size:1.35rem;font-weight:600;color:#F4F2EF;margin:0 0 .75rem}"
+        b"p{color:#A8A49C;line-height:1.55;margin:0}"
+        b".ok{color:#E0701B;font-family:ui-monospace,monospace;font-size:.75rem;"
+        b"letter-spacing:.12em;text-transform:uppercase;margin:0 0 .5rem}"
+        b"</style></head><body>"
+        b"<p class=ok>Signed in</p>"
+        b"<h1>You can close this tab</h1>"
+        b"<p>Return to your terminal - Cartograph finished logging you in.</p>"
+        b"</body></html>"
+    )
+    _ERROR_HTML = (
+        b"<!DOCTYPE html><html><head><meta charset=utf-8>"
+        b"<title>Cartograph - login error</title></head>"
+        b"<body style='font-family:system-ui;background:#14161C;color:#E8E6E3;"
+        b"max-width:28rem;margin:4rem auto;padding:0 1.25rem'>"
+        b"<h1>Login failed</h1>"
+        b"<p>Close this tab and try <code>cartograph login</code> again.</p>"
+        b"</body></html>"
+    )
 
     class _Handler(http.server.BaseHTTPRequestHandler):
         def do_GET(self):
@@ -1469,26 +1497,24 @@ def cmd_login(args):
                 if isinstance(val, list):
                     return val[0] if val else ""
                 return val or ""
+            # Preferred: opaque one-time code (no secrets in the address bar).
+            code = _first("code")
+            # Legacy fallback for older registry deploys that still query-dump tokens.
             id_token = _first("id_token")
-            if id_token:
+            ok = False
+            if code:
+                received["code"] = code
+                ok = True
+            elif id_token:
                 received["id_token"] = id_token
                 received["refresh_token"] = _first("refresh_token")
                 received["signing_key"] = _first("signing_key")
                 received["handle"] = _first("handle")
-                received["client_id"] = _first("client_id")
-                received["client_secret"] = _first("client_secret")
+                ok = True
             self.send_response(200)
-            self.send_header("Content-Type", "text/html")
+            self.send_header("Content-Type", "text/html; charset=utf-8")
             self.end_headers()
-            if id_token:
-                self.wfile.write(
-                    b"<html><body style='font-family:monospace;background:#0d1117;color:#e6edf3;"
-                    b"max-width:500px;margin:60px auto;padding:20px'>"
-                    b"<h2 style='color:#58a6ff'>Logged in</h2>"
-                    b"<p>You can close this tab and return to your terminal.</p></body></html>"
-                )
-            else:
-                self.wfile.write(b"")
+            self.wfile.write(_SUCCESS_HTML if ok else _ERROR_HTML)
 
         def log_message(self, *args):
             pass
@@ -1506,8 +1532,8 @@ def cmd_login(args):
 
     webbrowser.open(login_url)
 
-    # Keep serving until we get credentials or timeout
-    while "id_token" not in received:
+    # Keep serving until we get a code (or legacy tokens) or timeout
+    while "code" not in received and "id_token" not in received:
         server.handle_request()
         if server.timeout and not received:
             break
@@ -1515,16 +1541,37 @@ def cmd_login(args):
 
     id_token = received.get("id_token", "")
     handle = received.get("handle", "")
+    refresh_token = received.get("refresh_token", "")
+    signing_key = received.get("signing_key", "")
+
+    if received.get("code"):
+        # Exchange one-time code with the registry — secrets never hit the browser.
+        try:
+            req = urllib.request.Request(
+                f"{registry}/v1/auth/cli/complete",
+                data=_json.dumps({"code": received["code"]}).encode(),
+                headers={"Content-Type": "application/json", "Accept": "application/json"},
+                method="POST",
+            )
+            from .net_tls import registry_ssl_context
+            with urllib.request.urlopen(req, timeout=15, context=registry_ssl_context()) as resp:
+                payload = _json.loads(resp.read())
+        except Exception as e:
+            err({"error": f"Login code exchange failed: {e}"})
+        id_token = payload.get("id_token") or ""
+        refresh_token = payload.get("refresh_token") or ""
+        signing_key = payload.get("signing_key") or ""
+        handle = payload.get("handle") or handle
+
     if not id_token:
         err({"error": "Authentication timed out or was cancelled."})
 
+    # Never persist OAuth client secrets. Refresh goes through the registry.
     save_credentials(
         id_token,
-        received.get("refresh_token", ""),
-        received.get("signing_key", ""),
-        client_id=received.get("client_id", ""),
-        client_secret=received.get("client_secret", ""),
-        token_url=received.get("token_url", ""),
+        refresh_token,
+        signing_key,
+        token_url=f"{registry}/v1/auth/refresh",
     )
     print(f"  Logged in as @{handle}\n")
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -177,3 +177,113 @@ def test_cmd_logout_unknown_registry_errors(tmp_path, monkeypatch, capsys):
     out = capsys.readouterr()
     assert "not configured" in (out.out + out.err).lower()
     assert removed == []  # never touched any token store
+
+
+# ---------------------------------------------------------------------------
+# Token refresh routing - registry-mediated vs legacy IdP
+# ---------------------------------------------------------------------------
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = json.dumps(payload).encode()
+
+    def read(self):
+        return self._payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+def _write_creds(path, creds):
+    with open(path, "w") as f:
+        json.dump(creds, f)
+
+
+def test_refresh_routes_through_registry_when_no_secret(tmp_path, monkeypatch):
+    """Without a stored client_secret, refresh must POST JSON to the
+    registry /v1/auth/refresh - the secret lives server-side."""
+    creds_file = str(tmp_path / "creds.json")
+    monkeypatch.setattr("cartograph.auth._CREDENTIALS_FILE", creds_file)
+    _write_creds(creds_file, {"id_token": "old", "refresh_token": "r1"})
+    monkeypatch.setattr("cartograph.auth.get_registry_url",
+                        lambda: "https://api.example.com")
+
+    seen = {}
+
+    def fake_urlopen(req, timeout=None, context=None):
+        seen["url"] = req.full_url
+        seen["body"] = json.loads(req.data)
+        seen["content_type"] = req.get_header("Content-type")
+        return _FakeResponse({"id_token": "new-token"})
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    from cartograph.auth import _refresh_id_token
+    assert _refresh_id_token("r1") == "new-token"
+    assert seen["url"] == "https://api.example.com/v1/auth/refresh"
+    assert seen["body"] == {"refresh_token": "r1"}
+    assert "json" in seen["content_type"]
+
+
+def test_refresh_registry_success_drops_legacy_secret(tmp_path, monkeypatch):
+    """Once registry-mediated refresh works, any stored client_secret is
+    removed and token_url is pinned to the registry endpoint."""
+    creds_file = str(tmp_path / "creds.json")
+    monkeypatch.setattr("cartograph.auth._CREDENTIALS_FILE", creds_file)
+    _write_creds(creds_file, {"id_token": "old", "refresh_token": "r1",
+                              "client_secret": ""})
+    monkeypatch.setattr("cartograph.auth.get_registry_url",
+                        lambda: "https://api.example.com")
+    monkeypatch.setattr("urllib.request.urlopen",
+                        lambda req, timeout=None, context=None:
+                        _FakeResponse({"id_token": "new-token"}))
+    from cartograph.auth import _refresh_id_token
+    assert _refresh_id_token("r1") == "new-token"
+    with open(creds_file) as f:
+        stored = json.load(f)
+    assert stored["id_token"] == "new-token"
+    assert "client_secret" not in stored
+    assert stored["token_url"] == "https://api.example.com/v1/auth/refresh"
+
+
+def test_refresh_legacy_idp_path_still_form_posts(tmp_path, monkeypatch):
+    """Old logins (IdP token_url + stored client secret) keep working via
+    the direct form-POST path."""
+    creds_file = str(tmp_path / "creds.json")
+    monkeypatch.setattr("cartograph.auth._CREDENTIALS_FILE", creds_file)
+    _write_creds(creds_file, {
+        "id_token": "old", "refresh_token": "r1",
+        "token_url": "https://oauth2.example.com/token",
+        "client_id": "cid", "client_secret": "csecret",
+    })
+    monkeypatch.setattr("cartograph.auth._google_client_id", lambda: "cid")
+    monkeypatch.setattr("cartograph.auth._google_client_secret",
+                        lambda: "csecret")
+
+    seen = {}
+
+    def fake_urlopen(req, timeout=None, context=None):
+        seen["url"] = req.full_url
+        seen["body"] = req.data.decode()
+        return _FakeResponse({"id_token": "refreshed"})
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    from cartograph.auth import _refresh_id_token
+    assert _refresh_id_token("r1") == "refreshed"
+    assert seen["url"] == "https://oauth2.example.com/token"
+    assert "grant_type=refresh_token" in seen["body"]
+    assert "client_secret=csecret" in seen["body"]
+
+
+def test_refresh_refuses_http_registry(tmp_path, monkeypatch):
+    """A non-https registry refresh endpoint (other than localhost dev)
+    must be refused."""
+    creds_file = str(tmp_path / "creds.json")
+    monkeypatch.setattr("cartograph.auth._CREDENTIALS_FILE", creds_file)
+    _write_creds(creds_file, {"id_token": "old", "refresh_token": "r1"})
+    monkeypatch.setattr("cartograph.auth.get_registry_url",
+                        lambda: "http://api.example.com")
+    from cartograph.auth import _refresh_id_token
+    assert _refresh_id_token("r1") is None


### PR DESCRIPTION
## Summary

Client half of the cloud's hardened auth flow (cloud commit bab034e, already on cloud main):

- **Login**: the browser callback now carries an opaque one-time `code` only; the CLI exchanges it via `POST /v1/auth/cli/complete` for credentials. No tokens, signing keys, or client secrets ever appear in the browser URL. Legacy query-dump callbacks from older registry deploys still work.
- **Refresh**: `POST /v1/auth/refresh` on the registry (server holds the IdP client secret) whenever no local secret is stored or token_url already points at the registry. Legacy direct-IdP form-POST kept for credentials saved by older logins; a successful registry refresh drops any stored `client_secret` and pins `token_url` to the registry endpoint.
- New login success/error pages match the site look.
- 4 new tests covering refresh routing, secret-dropping, the legacy path, and the non-https refusal (15 auth tests total, all green).
- Version bumped to **0.7.17** - merge on green CI and the auto-tag/publish pipeline ships it to PyPI.

## Notes

- Ships ahead of the Lean engine PR (#43) per release ordering; #43 will be rebased/re-verified after this lands.
- Cloud side needs no change - both endpoints are already on cloud main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)