### PR TITLE
fix(login): don't treat browser preconnect as auth timeout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cartograph-cli"
-version = "0.7.20"
+version = "0.7.21"
 description = "Widget library manager for AI agents — CLI"
 readme = "README.md"
 license = "MIT"

--- a/src/cartograph/cli.py
+++ b/src/cartograph/cli.py
@@ -1520,7 +1520,7 @@ def cmd_login(args):
             pass
 
     server = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
-    server.timeout = 120
+    server.timeout = 5
     port = server.server_address[1]
     cli_redirect = f"http://127.0.0.1:{port}/callback"
 
@@ -1532,11 +1532,16 @@ def cmd_login(args):
 
     webbrowser.open(login_url)
 
-    # Keep serving until we get a code (or legacy tokens) or timeout
-    while "code" not in received and "id_token" not in received:
+    # Keep serving until we get a code (or legacy tokens) or the overall
+    # deadline passes. Browsers open speculative connections to localhost
+    # that never send a request (Chrome preconnect); handle_request()
+    # returns for those with nothing received, so an empty pass must NOT
+    # be treated as the timeout - only the wall clock decides.
+    import time as _time
+    deadline = _time.monotonic() + 120
+    while ("code" not in received and "id_token" not in received
+           and _time.monotonic() < deadline):
         server.handle_request()
-        if server.timeout and not received:
-            break
     server.server_close()
 
     id_token = received.get("id_token", "")


### PR DESCRIPTION
`cartograph login` was failing with 'Authentication timed out or was cancelled' even though the browser flow succeeded (server logs: login 307 → callback 307 → no `cli/complete` POST ever arrives).

Root cause: the callback serve loop treated any `handle_request()` pass that received nothing as the timeout. Chrome opens speculative preconnect sockets to localhost that never send a request, so the first empty pass killed the CLI's local server before the real redirect landed - the browser then got connection refused.

Fix: serve until a code (or legacy token) arrives or a 120s wall-clock deadline passes. Reproduced against prod with a scripted preconnect + callback: before = connection refused / timeout; after = callback 200 and the code exchange proceeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SiGyJAufyc11knM4N4gU1w