### PR TITLE
fix(cloud): case-insensitive response header lookup in download_widget

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cartograph-cli"
-version = "0.7.21"
+version = "0.7.22"
 description = "Widget library manager for AI agents — CLI"
 readme = "README.md"
 license = "MIT"

--- a/src/cartograph/cloud.py
+++ b/src/cartograph/cloud.py
@@ -416,9 +416,11 @@ def download_widget(owner_handle: str, widget_id: str,
     )
     if "error" in r:
         return r
-    headers = r["headers"]
+    # HTTP header names are case-insensitive and proxies rewrite them
+    # (Google Front End lowercases everything), so normalize before lookup.
+    headers = {k.lower(): v for k, v in r["headers"].items()}
     stamp = None
-    raw_stamp = headers.get("X-Widget-Stamp")
+    raw_stamp = headers.get("x-widget-stamp")
     if raw_stamp:
         try:
             stamp = json.loads(raw_stamp)
@@ -426,8 +428,8 @@ def download_widget(owner_handle: str, widget_id: str,
             stamp = None  # malformed header: fall back to unstamped install
     return {
         "zip_bytes": r["body"],
-        "version": headers.get("X-Widget-Version", "0.0.0"),
-        "governance": headers.get("X-Widget-Governance"),
+        "version": headers.get("x-widget-version", "0.0.0"),
+        "governance": headers.get("x-widget-governance"),
         "stamp": stamp,
     }
 

--- a/tests/test_stamp_adoption.py
+++ b/tests/test_stamp_adoption.py
@@ -110,8 +110,10 @@ def test_download_widget_parses_stamp_header(monkeypatch):
             return {
                 "body": b"zipbytes",
                 "headers": {
-                    "X-Widget-Version": "1.2.3",
-                    "X-Widget-Stamp": json.dumps(stamp),
+                    # Google Front End lowercases response headers; the
+                    # client must do case-insensitive lookup.
+                    "x-widget-version": "1.2.3",
+                    "x-widget-stamp": json.dumps(stamp),
                 },
             }
 
@@ -126,11 +128,25 @@ def test_download_widget_malformed_stamp_header(monkeypatch):
 
     class _FakeClient:
         def request_raw(self, *a, **k):
-            return {"body": b"z", "headers": {"X-Widget-Stamp": "not json"}}
+            return {"body": b"z", "headers": {"x-widget-stamp": "not json"}}
 
     monkeypatch.setattr(cloud, "_http_client", lambda: _FakeClient())
     r = cloud.download_widget("owner", "universal-demo-python")
     assert r["stamp"] is None
+
+
+def test_download_widget_canonical_case_headers(monkeypatch):
+    """Direct-origin responses keep canonical casing; lookup must be
+    case-insensitive in both directions."""
+    from cartograph import cloud
+
+    class _FakeClient:
+        def request_raw(self, *a, **k):
+            return {"body": b"z", "headers": {"X-Widget-Version": "2.0.0"}}
+
+    monkeypatch.setattr(cloud, "_http_client", lambda: _FakeClient())
+    r = cloud.download_widget("owner", "universal-demo-python")
+    assert r["version"] == "2.0.0"
 
 
 def test_download_widget_no_stamp_header(monkeypatch):
@@ -138,7 +154,7 @@ def test_download_widget_no_stamp_header(monkeypatch):
 
     class _FakeClient:
         def request_raw(self, *a, **k):
-            return {"body": b"z", "headers": {"X-Widget-Version": "1.0.0"}}
+            return {"body": b"z", "headers": {"X-Widget-Version": "1.0.0"}}  # canonical case must also work
 
     monkeypatch.setattr(cloud, "_http_client", lambda: _FakeClient())
     r = cloud.download_widget("owner", "universal-demo-python")


### PR DESCRIPTION
Follow-up to #47: against prod, every download reported `v0.0.0` and stamp adoption never fired - Google Front End lowercases response headers, and `download_widget` looked up canonical-case names. The unit fakes used canonical casing too, so CI never caught it.

Fix: normalize header keys to lowercase before lookup. Tests now cover both lowercased (GFE) and canonical-case (direct origin) responses. Verified against prod: version and stamp fingerprint both come through, and the stamp signature verifies with the current key.

Bumps 0.7.22 so the library heal can actually run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SiGyJAufyc11knM4N4gU1w